### PR TITLE
Fix exception in CLI

### DIFF
--- a/liminal/cli/cli.py
+++ b/liminal/cli/cli.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-import sys
 from pathlib import Path
 
 import typer
@@ -218,15 +217,4 @@ def live_test(
 
 
 print("Starting Liminal CLI...")
-if sys.argv[1:] and (
-    not sys.argv[1]
-    or sys.argv[1] in ["init"]
-    or "--help" in sys.argv
-    or "-h" in sys.argv
-):
-    app()
-else:
-    print(sys.argv)
-    raise Exception(
-        f"No {ENV_FILE_PATH} file found. Run `liminal init` or check your directory."
-    )
+app()

--- a/liminal/migrate/utils.py
+++ b/liminal/migrate/utils.py
@@ -4,13 +4,21 @@ from pathlib import Path
 from liminal.connection.benchling_connection import BenchlingConnection
 
 
+def _check_env_file(env_file_path: Path) -> None:
+    """Raises an exception if the env.py file does not exist at the given path."""
+    if not env_file_path.exists():
+        raise Exception(
+            f"No {env_file_path} file found. Run `liminal init` or check your current working directory for liminal/env.py."
+        )
+
+
 def read_local_env_file(
     env_file_path: Path, benchling_tenant: str
 ) -> tuple[str, BenchlingConnection]:
     """Imports the env.py file from the current working directory and returns the CURRENT_REVISION_ID variable.
     The env.py file is expected to have the CURRENT_REVISION_ID variable set to the revision id you are currently on.
     """
-
+    _check_env_file(env_file_path)
     module_path = Path.cwd() / env_file_path
     spec = importlib.util.spec_from_file_location(env_file_path.stem, module_path)
     if spec is None or spec.loader is None:


### PR DESCRIPTION
Fixes exception in CLI when running any `liminal` command raises an exception due to jumbled logic in `cli.py`.

Now, validate within function `read_local_env_file`, which is the function that depends on env.py to exist. `read_local_env_file` is run at the start of every cli command to import in the external dropdowns/schemas.

Reproduced bug and tested locally to confirm