### PR TITLE
Fix generate files import bug

### DIFF
--- a/liminal/cli/controller.py
+++ b/liminal/cli/controller.py
@@ -21,13 +21,7 @@ def generate_all_files(benchling_service: BenchlingService, write_path: Path) ->
     write_path : Path
         The path to write the generated files to.
     """
-    dropdowns_init_path = generate_all_dropdown_files(benchling_service, write_path)
-    if dropdowns_init_path is not None:
-        exec(dropdowns_init_path.read_text())
-    else:
-        raise Exception(
-            f"No dropdown imports found in the generated {dropdowns_init_path} file."
-        )
+    generate_all_dropdown_files(benchling_service, write_path)
     generate_all_entity_schema_files(benchling_service, write_path)
 
 

--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -9,7 +9,7 @@ from liminal.utils import pascalize, to_snake_case
 
 def generate_all_dropdown_files(
     benchling_service: BenchlingService, write_path: Path
-) -> Path:
+) -> None:
     """Generate all dropdown files from your Benchling tenant and writes to the given dropdowns/ path.
     This is used to initialize your code for Liminal and transfer the information from your Benchling tenant to your local codebase.
     Note: This will overwrite any existing dropdowns that exist in the given path.
@@ -48,5 +48,3 @@ class {classname}(BaseDropdown):
         print(
             f"[green]Generated {write_path / '__init__.py'} with {len(file_names_to_classname)} dropdown imports."
         )
-
-    return write_path / "__init__.py"


### PR DESCRIPTION
Fixes a bug in `liminal generate-files` where the relative dropdown imports were not getting recognized in the `exec`.

Instead of passing around the imports, instead re-retrieve the dropdowns map using the benchling api when generating the entity schema files.

Reproduced bug. Tested locally by running `generate-files` and verifying that schema files generated are valid