### PR TITLE
Fix dropdown generate files to ignore archived

### DIFF
--- a/liminal/dropdowns/compare.py
+++ b/liminal/dropdowns/compare.py
@@ -19,7 +19,7 @@ def compare_dropdowns(
 ) -> dict[str, list[CompareOperation]]:
     dropdown_operations: dict[str, list[CompareOperation]] = {}
     benchling_dropdowns: dict[str, Dropdown] = get_benchling_dropdowns_dict(
-        benchling_service
+        benchling_service, include_archived=True
     )
     processed_benchling_names = set()
     model_dropdowns = BaseDropdown.get_all_subclasses(dropdown_names)

--- a/liminal/entity_schemas/utils.py
+++ b/liminal/entity_schemas/utils.py
@@ -41,6 +41,9 @@ def convert_tag_schema_to_internal_schema(
     dropdowns_map: dict[str, str],
     include_archived_fields: bool = False,
 ) -> tuple[SchemaProperties, dict[str, BaseFieldProperties]]:
+    all_fields = tag_schema.allFields
+    if not include_archived_fields:
+        all_fields = [f for f in all_fields if not f.archiveRecord]
     return (
         SchemaProperties(
             name=tag_schema.name,
@@ -63,11 +66,7 @@ def convert_tag_schema_to_internal_schema(
         ).set_archived(tag_schema.archiveRecord is not None),
         {
             f.systemName: convert_tag_schema_field_to_field_properties(f, dropdowns_map)
-            for f in (
-                tag_schema.allFields
-                if include_archived_fields
-                else [f for f in tag_schema.allFields if not f.archiveRecord]
-            )
+            for f in all_fields
         },
     )
 


### PR DESCRIPTION
Bug where `generate_files` for dropdowns was generating archived dropdowns and options. 

Added a flag to the function so that you have the choice to ignore or include archived dropdowns/options. This mirrors the logic for `generate_files` in entity schemas.

Tested locally through generate files CLI command.