### PR TITLE
fix schema properties bug

### DIFF
--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -97,3 +97,12 @@ class BaseSchemaProperties(BaseModel):
         if not isinstance(other, BaseSchemaProperties):
             return False
         return self.model_dump() == other.model_dump()
+
+    def __str__(self) -> str:
+        return ", ".join(
+            [f"{k}={v}" for k, v in self.model_dump(exclude_unset=True).items()]
+        )
+
+    def __repr__(self) -> str:
+        """Generates a string representation of the class so that it can be executed."""
+        return f"{self.__class__.__name__}({', '.join([f'{k}={v.__repr__()}' for k, v in self.model_dump(exclude_defaults=True).items()])})"

--- a/liminal/cli/cli.py
+++ b/liminal/cli/cli.py
@@ -79,7 +79,10 @@ def generate_files(
         ..., help="Benchling tenant (or alias) to connect to."
     ),
     write_path: Path = typer.Option(
-        Path("."), help="The path to write the generated files to."
+        Path("."),
+        "-p",
+        "--write-path",
+        help="The path to write the generated files to.",
     ),
 ) -> None:
     current_revision_id, benchling_connection = read_local_env_file(

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -195,10 +195,10 @@ class UpdateEntitySchema(BaseOperation):
         return update_tag_schema(benchling_service, tag_schema.id, update.model_dump())
 
     def describe_operation(self) -> str:
-        return f"Updating properties for entity schema {self.wh_schema_name}: {repr(self.update_props)}."
+        return f"Updating properties for entity schema {self.wh_schema_name}: {str(self.update_props)}."
 
     def describe(self) -> str:
-        return f"Schema properties for {self.wh_schema_name} are different in code versus Benchling: {repr(self.update_props)}."
+        return f"Schema properties for {self.wh_schema_name} are different in code versus Benchling: {str(self.update_props)}."
 
     def _validate(self, benchling_service: BenchlingService) -> TagSchemaModel:
         all_schemas = TagSchemaModel.get_all_json(benchling_service)
@@ -485,11 +485,7 @@ class UpdateEntitySchemaField(BaseOperation):
         # Only if changing name of field
         if self.update_props.name:
             existing_new_field = next(
-                (
-                    f
-                    for f in tag_schema.allFields
-                    if f.systemName == self.update_props.name
-                ),
+                (f for f in tag_schema.allFields if f.name == self.update_props.name),
                 None,
             )
             if existing_new_field:


### PR DESCRIPTION
Tested locally and ensures this now works.

Bug was that BaseSchemaProperties didn't have its repr overridden which excluded default values. This meant in the revision file, it would write BaseSchemaProperties with a bunch of Nones (which means it would try to set those properties to None which is incorrect).