### PR TITLE
allow sqlalchemy aliasing

### DIFF
--- a/liminal/connection/benchling_service.py
+++ b/liminal/connection/benchling_service.py
@@ -9,7 +9,12 @@ from bs4 import BeautifulSoup
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.orm import Session, configure_mappers
-from tenacity import retry, retry_if_exception_type, stop_after_attempt
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from liminal.connection.benchling_connection import BenchlingConnection
 
@@ -144,6 +149,7 @@ class BenchlingService(Benchling):
     @retry(
         stop=stop_after_attempt(3),
         retry=retry_if_exception_type(ValueError),
+        wait=wait_exponential(multiplier=1, min=1, max=8),
         reraise=True,
     )
     def autogenerate_auth(

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -82,7 +82,7 @@ class Column(SqlColumn):
         super().__init__(
             self.sqlalchemy_type,
             foreign_key,
-            nullable=not properties.required,
+            nullable=not required,
             info={"benchling_properties": properties},
             **kwargs,
         )
@@ -107,3 +107,7 @@ class Column(SqlColumn):
                 f"Could not set benchling properties for column {column.name}. Please check that the column has a valid benchling properties set."
             )
         return Column(**properties.model_dump())
+
+    def _constructor(self, *args: Any, **kwargs: Any) -> SqlColumn:
+        """Returns a new instance of the SqlAlchemy Column class."""
+        return SqlColumn(*args, **kwargs)


### PR DESCRIPTION
add _constructor() so that SQLAlchemy can alias tables. Also, makes retry logic of BenchlingService more robust.

Tested locally to ensure this works