### PR TITLE
change array to json for column sqlalchemy type

### DIFF
--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -1,7 +1,8 @@
 from typing import Any, Type  # noqa: UP035
 
-from sqlalchemy import ARRAY, ForeignKey
-from sqlalchemy import Column as SqlColumn
+from sqlalchemy.sql.schema import Column as SqlColumn
+from sqlalchemy.sql.schema import ForeignKey
+from sqlalchemy.types import JSON
 
 from liminal.base.base_dropdown import BaseDropdown
 from liminal.base.properties.base_field_properties import BaseFieldProperties
@@ -60,7 +61,7 @@ class Column(SqlColumn):
         self.properties = properties
 
         nested_sql_type = convert_benchling_type_to_sql_alchemy_type(type)
-        sqlalchemy_type = ARRAY(nested_sql_type) if is_multi else nested_sql_type
+        sqlalchemy_type = JSON if is_multi else nested_sql_type
         if dropdown and type != BenchlingFieldType.DROPDOWN:
             raise ValueError("Dropdown can only be set if the field type is DROPDOWN.")
         if dropdown is None and type == BenchlingFieldType.DROPDOWN:


### PR DESCRIPTION
JSON is the generic sqlalchemy type for representing list columns. 
ARRAY was specific to postgres