### PR TITLE
be able to define archived fields on entity schemas

### DIFF
--- a/liminal/base/properties/base_field_properties.py
+++ b/liminal/base/properties/base_field_properties.py
@@ -53,6 +53,10 @@ class BaseFieldProperties(BaseModel):
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._archived = data.get("_archived", None)
+
     def set_archived(self, value: bool) -> BaseFieldProperties:
         self._archived = value
         return self

--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from liminal.enums import BenchlingEntityType, BenchlingNamingStrategy
 
@@ -69,7 +69,11 @@ class BaseSchemaProperties(BaseModel):
     entity_type: BenchlingEntityType | None = None
     naming_strategies: set[BenchlingNamingStrategy] | None = None
     mixture_schema_config: MixtureSchemaConfig | None = None
-    _archived: bool | None = PrivateAttr(default=None)
+    _archived: bool | None = None
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._archived = data.get("_archived", None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 

--- a/liminal/entity_schemas/compare.py
+++ b/liminal/entity_schemas/compare.py
@@ -43,7 +43,11 @@ def compare_entity_schemas(
     )
     # If models are provided, filter the schemas from benchling so that only the models passed in are compared.
     # If you don't filter, it will compare to all the schemas in benchling and think that they are missing from code and should be archived.
-    models = BaseModel.get_all_subclasses(schema_names)
+    models = [
+        m
+        for m in BaseModel.get_all_subclasses(schema_names)
+        if not m.__schema_properties__._archived
+    ]
     archived_benchling_schema_wh_names = [
         s.warehouse_name for s, _ in benchling_schemas if s._archived is True
     ]

--- a/liminal/entity_schemas/utils.py
+++ b/liminal/entity_schemas/utils.py
@@ -63,7 +63,8 @@ def convert_tag_schema_to_internal_schema(
                 BenchlingNamingStrategy(strategy)
                 for strategy in tag_schema.labelingStrategies
             ),
-        ).set_archived(tag_schema.archiveRecord is not None),
+            _archived=tag_schema.archiveRecord is not None,
+        ),
         {
             f.systemName: convert_tag_schema_field_to_field_properties(f, dropdowns_map)
             for f in all_fields
@@ -90,7 +91,8 @@ def convert_tag_schema_field_to_field_properties(
         if field.requiredLink and field.requiredLink.tagSchema
         else None,
         tooltip=field.tooltipText,
-    ).set_archived(field.archiveRecord is not None)
+        _archived=field.archiveRecord is not None,
+    )
 
 
 def get_benchling_entity_schemas(

--- a/liminal/orm/base_model.py
+++ b/liminal/orm/base_model.py
@@ -108,7 +108,9 @@ class BaseModel(Generic[T], Base):
         return list(models.values())
 
     @classmethod
-    def get_columns_dict(cls, exclude_base_columns: bool = False) -> dict[str, Column]:
+    def get_columns_dict(
+        cls, exclude_base_columns: bool = False, exclude_archived: bool = True
+    ) -> dict[str, Column]:
         """Returns a dictionary of all benchling columns in the class. Benchling Column saves an instance of itself to the sqlalchemy Column info property.
         This function retrieves the info property and returns a dictionary of the columns.
         """
@@ -124,6 +126,8 @@ class BaseModel(Generic[T], Base):
                 )
             fields_to_exclude.append("creator_id$")
         columns = [c for c in cls.__table__.columns if c.name not in fields_to_exclude]
+        if exclude_archived:
+            columns = [c for c in columns if not c.properties._archived]
         return {c.name: c for c in columns}
 
     @classmethod

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -43,6 +43,7 @@ class Column(SqlColumn):
         tooltip: str | None = None,
         dropdown: Type[BaseDropdown] | None = None,  # noqa: UP006
         entity_link: str | None = None,
+        _archived: bool = False,
         **kwargs: Any,
     ):
         """Initializes a Benchling Column object. Validates the type BenchlingFieldType maps to a valid sqlalchemy type.
@@ -56,7 +57,7 @@ class Column(SqlColumn):
             dropdown_link=dropdown.__benchling_name__ if dropdown else None,
             entity_link=entity_link,
             tooltip=tooltip,
-        )
+        ).set_archived(_archived)
         self.properties = properties
 
         nested_sql_type = convert_benchling_type_to_sql_alchemy_type(type)

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -57,7 +57,8 @@ class Column(SqlColumn):
             dropdown_link=dropdown.__benchling_name__ if dropdown else None,
             entity_link=entity_link,
             tooltip=tooltip,
-        ).set_archived(_archived)
+            _archived=_archived,
+        )
         self.properties = properties
 
         nested_sql_type = convert_benchling_type_to_sql_alchemy_type(type)

--- a/liminal/orm/schema_properties.py
+++ b/liminal/orm/schema_properties.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pydantic import PrivateAttr, model_validator
+from typing import Any
+
+from pydantic import model_validator
 
 from liminal.base.properties.base_schema_properties import (
     BaseSchemaProperties,
@@ -22,7 +24,11 @@ class SchemaProperties(BaseSchemaProperties):
     entity_type: BenchlingEntityType
     naming_strategies: set[BenchlingNamingStrategy]
     mixture_schema_config: MixtureSchemaConfig | None = None
-    _archived: bool | None = PrivateAttr(default=None)
+    _archived: bool = False
+
+    def __init__(self, **data: Any):
+        super().__init__(**data)
+        self._archived = data.get("_archived", False)
 
     @model_validator(mode="after")
     def validate_mixture_schema_config(self) -> SchemaProperties:

--- a/liminal/tests/conftest.py
+++ b/liminal/tests/conftest.py
@@ -136,7 +136,8 @@ def mock_benchling_schema(
             parent_link=False,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "string_field_req": Props(
             name="String Field Required",
             type=Type.TEXT,
@@ -146,7 +147,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "string_field_not_req": Props(
             name="String Field Not Required",
             type=Type.TEXT,
@@ -156,7 +158,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "string_field_tooltip": Props(
             name="String Field Not Required",
             type=Type.TEXT,
@@ -166,7 +169,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip="test tooltip",
-        ).set_archived(False),
+            _archived=False,
+        ),
         "float_field": Props(
             name="Float Field",
             type=Type.DECIMAL,
@@ -176,7 +180,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "integer_field": Props(
             name="Integer Field",
             type=Type.INTEGER,
@@ -186,7 +191,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "datetime_field": Props(
             name="Datetime Field",
             type=Type.DATE,
@@ -196,7 +202,8 @@ def mock_benchling_schema(
             dropdown_link=None,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "list_dropdown_field": Props(
             name="List Dropdown Field",
             type=Type.DROPDOWN,
@@ -206,7 +213,8 @@ def mock_benchling_schema(
             parent_link=False,
             entity_link=None,
             tooltip=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
     }
     return [(schema_props, fields)]
 
@@ -229,32 +237,51 @@ def mock_benchling_schema_one(
             required=False,
             is_multi=False,
             dropdown_link=mock_benchling_dropdown.__benchling_name__,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "string_field_req": Props(
-            name="String Field Required", type=Type.TEXT, required=True, is_multi=False
-        ).set_archived(False),
+            name="String Field Required",
+            type=Type.TEXT,
+            required=True,
+            is_multi=False,
+            _archived=False,
+        ),
         "string_field_not_req": Props(
             name="String Field Not Required",
             type=Type.TEXT,
             required=False,
             is_multi=False,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "float_field": Props(
-            name="Float Field", type=Type.DECIMAL, required=False, is_multi=False
-        ).set_archived(False),
+            name="Float Field",
+            type=Type.DECIMAL,
+            required=False,
+            is_multi=False,
+            _archived=False,
+        ),
         "integer_field": Props(
-            name="Integer Field", type=Type.INTEGER, required=False, is_multi=False
-        ).set_archived(False),
+            name="Integer Field",
+            type=Type.INTEGER,
+            required=False,
+            is_multi=False,
+            _archived=False,
+        ),
         "datetime_field": Props(
-            name="Datetime Field", type=Type.DATE, required=False, is_multi=False
-        ).set_archived(False),
+            name="Datetime Field",
+            type=Type.DATE,
+            required=False,
+            is_multi=False,
+            _archived=False,
+        ),
         "list_dropdown_field": Props(
             name="List Dropdown Field",
             type=Type.DROPDOWN,
             required=False,
             is_multi=True,
             dropdown_link=mock_benchling_dropdown.__benchling_name__,
-        ).set_archived(False),
+            _archived=False,
+        ),
     }
     return [(schema_props, fields)]
 
@@ -267,7 +294,8 @@ def mock_benchling_schema_archived() -> list[tuple[SchemaProperties, dict[str, P
         prefix="MockEntitySmall",
         entity_type=BenchlingEntityType.CUSTOM_ENTITY,
         naming_strategies=[BenchlingNamingStrategy.NEW_IDS],
-    ).set_archived(True)
+        _archived=True,
+    )
     fields = {
         "string_field_req": Props(
             name="String Field Required",
@@ -278,14 +306,16 @@ def mock_benchling_schema_archived() -> list[tuple[SchemaProperties, dict[str, P
             tooltip=None,
             dropdown_link=None,
             entity_link=None,
-        ).set_archived(False),
+            _archived=False,
+        ),
         "string_field_req_2": Props(
             name="String Field Required 2",
             type=Type.TEXT,
             required=True,
             parent_link=False,
             is_multi=False,
-        ).set_archived(False),
+            _archived=False,
+        ),
     }
     return [(schema_props, fields)]
 

--- a/liminal/tests/test_entity_schema_compare.py
+++ b/liminal/tests/test_entity_schema_compare.py
@@ -168,7 +168,8 @@ class TestCompareEntitySchemas:
                 required=False,
                 is_multi=False,
                 dropdown_link=None,
-            ).set_archived(False)
+                _archived=False,
+            )
 
             mock_get_benchling_entity_schemas.return_value = extra_field
             invalid_models = compare_entity_schemas(mock_benchling_sdk)

--- a/liminal/tests/test_entity_schema_compare.py
+++ b/liminal/tests/test_entity_schema_compare.py
@@ -156,7 +156,7 @@ class TestCompareEntitySchemas:
                 invalid_models["mock_entity"][0].op.field_props.warehouse_name
                 == "string_field_req"
             )
-            mock_benchling_subclass[0].get_columns_dict()[
+            mock_benchling_subclass[0].get_columns_dict(exclude_base_columns=True)[
                 "string_field_req"
             ].properties.warehouse_name = None
 


### PR DESCRIPTION
This PR allows users to mark schemas and fields as archived in code. This was motivated by allowing users to access and query archived columns that still exist in the warehouse.

Tested operations locally for schemas fields