### PR TITLE
revert incorrect logic from previous pr

### DIFF
--- a/liminal/base/properties/base_field_properties.py
+++ b/liminal/base/properties/base_field_properties.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr
 from liminal.base.base_dropdown import BaseDropdown
 from liminal.enums import BenchlingFieldType
 from liminal.orm.base_model import BaseModel as BenchlingBaseModel
-from liminal.utils import is_valid_wh_name, to_snake_case
+from liminal.utils import is_valid_wh_name
 
 
 class BaseFieldProperties(BaseModel):
@@ -61,7 +61,7 @@ class BaseFieldProperties(BaseModel):
         self.warehouse_name = wh_name
         return self
 
-    def validate_column(self, wh_name: str, warehouse_access: bool = False) -> bool:
+    def validate_column(self, wh_name: str) -> bool:
         """If the Field Properties are meant to represent a column in Benchling,
         this will validate the properties and ensure that the entity_link and dropdowns are valid names that exist in our code.
         """
@@ -84,13 +84,6 @@ class BaseFieldProperties(BaseModel):
             raise ValueError(
                 f"Invalid warehouse name '{wh_name}'. It should only contain alphanumeric characters and underscores."
             )
-        if not warehouse_access:
-            if wh_name != to_snake_case(self.name):
-                raise ValueError(
-                    f"Warehouse access is required to set a custom field warehouse name. \
-                    Either set warehouse_access to True in BenchlingConnection or set the column variable name to the given Benchling field warehouse name: {to_snake_case(self.name)}. \
-                    Reach out to Benchling support if you need help setting up warehouse access."
-                )
         return True
 
     def merge(self, new_props: BaseFieldProperties) -> dict[str, Any]:

--- a/liminal/entity_schemas/compare.py
+++ b/liminal/entity_schemas/compare.py
@@ -13,9 +13,7 @@ from liminal.entity_schemas.operations import (
     UpdateEntitySchema,
     UpdateEntitySchemaField,
 )
-from liminal.entity_schemas.utils import (
-    get_converted_tag_schemas,
-)
+from liminal.entity_schemas.utils import get_converted_tag_schemas
 from liminal.orm.base_model import BaseModel
 from liminal.orm.column import Column
 from liminal.utils import to_snake_case
@@ -59,9 +57,7 @@ def compare_entity_schemas(
             exclude_base_columns=True
         )
         # Validate the entity_link and dropdown_link reference an entity_schema or dropdown that exists in code.
-        model.validate_model(
-            warehouse_access=benchling_service.connection.warehouse_access
-        )
+        model.validate_model()
         # if the model table_name is found in the benchling schemas, check for changes...
         if (model_wh_name := model.__schema_properties__.warehouse_name) in [
             s.warehouse_name for s, _ in benchling_schemas

--- a/liminal/orm/base_model.py
+++ b/liminal/orm/base_model.py
@@ -14,7 +14,6 @@ from liminal.base.base_validation_filters import BaseValidatorFilters
 from liminal.orm.base import Base
 from liminal.orm.schema_properties import SchemaProperties
 from liminal.orm.user import User
-from liminal.utils import to_snake_case
 from liminal.validation import (
     BenchlingValidator,
     BenchlingValidatorReport,
@@ -127,22 +126,13 @@ class BaseModel(Generic[T], Base):
         return {c.name: c for c in columns}
 
     @classmethod
-    def validate_model(cls, warehouse_access: bool = False) -> bool:
+    def validate_model(cls) -> bool:
         model_columns = cls.get_columns_dict(exclude_base_columns=True)
         properties = {n: c.properties for n, c in model_columns.items()}
         errors = []
-        if not warehouse_access:
-            if cls.__schema_properties__.warehouse_name != to_snake_case(
-                cls.__schema_properties__.name
-            ):
-                raise ValueError(
-                    f"Warehouse access is required to set a custom schema warehouse name. \
-                    Either set warehouse_access to True in BenchlingConnection or use the given Benchling schema warehouse name: {to_snake_case(cls.__schema_properties__.name)}. \
-                    Reach out to Benchling support if you need help setting up warehouse access."
-                )
         for wh_name, field in properties.items():
             try:
-                field.validate_column(wh_name, warehouse_access)
+                field.validate_column(wh_name)
             except ValueError as e:
                 errors.append(str(e))
         if errors:


### PR DESCRIPTION
Reverts the warehouse_name logic from this PR - https://github.com/dynotx/liminal-orm/pull/54

without warehouse access I realized that users aren’t able to update warehouse names for fields. However, Liminal didn’t have a way of recognizing this limitation so changing
`toppings = Column("Toppings", ...)`  --> `toppings_new = Column("Toppings", ...)`  through an UpdateEntitySchemaField operation was failing silently.

However I realized my implementation was wrong. I was thinking of the case where if warehouse access is turned on, it would be good to have the warehouse names tracked still, but enforcing `to_snakecase(name)` doesn’t make sense.
I’m going to revert the logic from this PR and will create a follow up PR.