### PR TITLE
block warehouse name changes to operations

### DIFF
--- a/liminal/base/base_operation.py
+++ b/liminal/base/base_operation.py
@@ -34,7 +34,7 @@ class BaseOperation(ABC):
         self.args = args
         self.kwargs = kwargs
 
-    def validate(self) -> None:
+    def validate(self, benchling_service: BenchlingService) -> None:
         """Validate the operation before running it. This is not called at runtime,
         but is used to validate operations before a migration is run."""
         pass

--- a/liminal/cli/live_test_dropdown_migration.py
+++ b/liminal/cli/live_test_dropdown_migration.py
@@ -69,7 +69,7 @@ def mock_dropdown_full_migration(
         unarchive_dropdown_op,
         rearchive_dropdown_op,
     ]
-    execute_operations_dry_run(ops) if dry_run else execute_operations(
+    execute_operations_dry_run(
         benchling_service, ops
-    )
+    ) if dry_run else execute_operations(benchling_service, ops)
     print("Dry run migration complete!") if dry_run else print("Migration complete!")

--- a/liminal/cli/live_test_entity_schema_migration.py
+++ b/liminal/cli/live_test_entity_schema_migration.py
@@ -139,7 +139,7 @@ def mock_entity_schema_full_migration(
         unarchive_entity_schema_op,
         rearchive_entity_schema_op,
     ]
-    execute_operations_dry_run(ops) if dry_run else execute_operations(
+    execute_operations_dry_run(
         benchling_service, ops
-    )
+    ) if dry_run else execute_operations(benchling_service, ops)
     print("Dry run migration complete!") if dry_run else print("Migration complete!")

--- a/liminal/dropdowns/operations.py
+++ b/liminal/dropdowns/operations.py
@@ -87,7 +87,7 @@ class ArchiveDropdown(BaseOperation):
             raise ValueError(f"Dropdown {self.dropdown_name} is already archived.")
         return archive_dropdown(benchling_service, dropdown.id)
 
-    def validate(self) -> None:
+    def validate(self, benchling_service: BenchlingService) -> None:
         if schemas_with_dropdown := get_schemas_with_dropdown(self.dropdown_name):
             raise ValueError(
                 f"Dropdown {self.dropdown_name} is used in schemas {schemas_with_dropdown}. Cannot archive a dropdown that is in use in non-archived fields."

--- a/liminal/migrate/components.py
+++ b/liminal/migrate/components.py
@@ -66,7 +66,7 @@ def execute_operations(
 ) -> bool:
     """This runs the given operations. It validates the operations and then executes them."""
     for o in operations:
-        o.validate()
+        o.validate(benchling_service)
 
     print("[bold]Executing operations...")
     index = 1
@@ -82,11 +82,13 @@ def execute_operations(
     return True
 
 
-def execute_operations_dry_run(operations: list[BaseOperation]) -> None:
+def execute_operations_dry_run(
+    benchling_service: BenchlingService, operations: list[BaseOperation]
+) -> None:
     """This runs the given operations in dry run mode. It only prints a description of the operations and validates them."""
     print("[bold]Executing dry run of operations...")
     index = 1
     for o in operations:
         print(f"{index}. {o.describe()}")
-        o.validate()
+        o.validate(benchling_service)
         index += 1


### PR DESCRIPTION
This PR revisits what https://github.com/dynotx/liminal-orm/pull/54/files attempted to do.
This PR https://github.com/dynotx/liminal-orm/pull/69 reverted the logic changes.

Without warehouse access, you are unable to change warehouse names for schemas/fields. When fields/schemas are created, the warehouse_name is generated and then cannot be changed by users. This PR enforces these rules in the operations.
- In the create operations, it ensures that the warehouse names match what would be generated from Benchling
- In the update operations, it does not allow any updating of warehouse names

The validate function on all operations run before any operations are executed