### PR TITLE
alias warehouse names for columns

### DIFF
--- a/docs/reference/entity-schemas.md
+++ b/docs/reference/entity-schemas.md
@@ -106,6 +106,13 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
 
 > The mixture schema configuration for the entity schema. Must be defined as a [MixtureSchemaConfig](https://github.com/dynotx/liminal-orm/blob/main/liminal/base/properties/base_schema_properties.py) object.
 
+**_archived: bool | None = None**
+
+> Private attribute used to set the archived status of the schema.
+
+!!! tip
+    When schemas (and fields) are archived, they still existing the Benchling warehouse. Using _archived is useful when you need to access archived data.
+
 ## Column: [class](https://github.com/dynotx/liminal-orm/blob/main/liminal/orm/column.py)
 
 !!! warning
@@ -135,6 +142,10 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
 
 > Whether the field is a parent link field. Defaults to False.
 
+**tooltip: str | None = None**
+
+> The tooltip for the field. Defaults to None.
+
 **dropdown: Type[BaseDropdown] | None = None**
 
 > The dropdown object for the field. The dropdown object must inherit from BaseDropdown and the type of the Column must be `BenchlingFieldType.DROPDOWN`. Defaults to None.
@@ -143,9 +154,13 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
 
 > The entity link for the field. The entity link must be the `warehouse_name` as a string of the entity schema that the field is linking to. The type of the Column must be `BenchlingFieldType.ENTITY_LINK` in order to be valid. Defaults to None.
 
-**tooltip: str | None = None**
+**_archived: bool = False**
 
-> The tooltip for the field. Defaults to None.
+> Private attribute used to set the archived status of the column.  Useful when you need to access archived data and want to define archived fields.
+
+**_warehouse_name: str | None = None**
+
+> Private attribute used to set the warehouse name of the column. This is useful when the variable name is not the same as the warehouse name.
 
 ## Relationships: [module](https://github.com/dynotx/liminal-orm/blob/main/liminal/orm/relationship.py)
 

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -26,12 +26,16 @@ class Column(SqlColumn):
         Whether the field is a multi-value field.
     parent_link : bool = False
         Whether the entity link field is a parent of the entity schema.
+    tooltip : str | None = None
+        The tooltip text for the field.
     dropdown : Type[BaseDropdown] | None = None
         The dropdown for the field.
     entity_link : str | None = None
         The warehouse name of the entity the field links to.
-    tooltip : str | None = None
-        The tooltip text for the field.
+    _warehouse_name : str | None = None
+        The warehouse name of the column. Necessary when the variable name is not the same as the warehouse name.
+    _archived : bool = False
+        Whether the field is archived.
     """
 
     def __init__(
@@ -44,6 +48,7 @@ class Column(SqlColumn):
         tooltip: str | None = None,
         dropdown: Type[BaseDropdown] | None = None,  # noqa: UP006
         entity_link: str | None = None,
+        _warehouse_name: str | None = None,
         _archived: bool = False,
         **kwargs: Any,
     ):
@@ -82,6 +87,8 @@ class Column(SqlColumn):
         foreign_key = None
         if type == BenchlingFieldType.ENTITY_LINK and entity_link:
             foreign_key = ForeignKey(f"{entity_link}$raw.id")
+        if _warehouse_name:
+            kwargs["name"] = _warehouse_name
         super().__init__(
             self.sqlalchemy_type,
             foreign_key,

--- a/liminal/tests/conftest.py
+++ b/liminal/tests/conftest.py
@@ -215,6 +215,24 @@ def mock_benchling_schema(
             tooltip=None,
             _archived=False,
         ),
+        "archived_field": Props(
+            name="Archived Field",
+            type=Type.TEXT,
+            required=False,
+            is_multi=False,
+            _archived=True,
+        ),
+        "wh_name_field_different": Props(
+            name="Different Wh Name Field",
+            type=Type.TEXT,
+            required=False,
+            is_multi=False,
+            parent_link=False,
+            dropdown_link=None,
+            entity_link=None,
+            tooltip=None,
+            _archived=False,
+        ),
     }
     return [(schema_props, fields)]
 
@@ -368,6 +386,20 @@ def mock_benchling_subclass(mock_benchling_dropdown) -> list[type[BaseModel]]:  
             required=False,
             is_multi=True,
             dropdown=mock_benchling_dropdown,
+        )
+        archived_field: SqlColumn = Column(
+            name="Archived Field",
+            type=Type.TEXT,
+            required=False,
+            is_multi=False,
+            _archived=True,
+        )
+        different_wh_name_field: SqlColumn = Column(
+            name="Different Wh Name Field",
+            type=Type.TEXT,
+            required=False,
+            is_multi=False,
+            _warehouse_name="wh_name_field_different",
         )
 
         def __init__(

--- a/liminal/tests/test_entity_schema_compare.py
+++ b/liminal/tests/test_entity_schema_compare.py
@@ -330,3 +330,14 @@ class TestCompareEntitySchemas:
             assert isinstance(
                 invalid_models["mock_entity"][0].op, ReorderEntitySchemaFields
             )
+
+            # Test when the Benchling schema archived field becomes unarchived
+            benchling_rearchived_field = copy.deepcopy(mock_benchling_schema)
+            benchling_rearchived_field[0][1]["archived_field"].set_archived(False)
+            mock_get_benchling_entity_schemas.return_value = benchling_rearchived_field
+            invalid_models = compare_entity_schemas(mock_benchling_sdk)
+            assert len(invalid_models["mock_entity"]) == 1
+            assert isinstance(
+                invalid_models["mock_entity"][0].op, ArchiveEntitySchemaField
+            )
+            assert invalid_models["mock_entity"][0].op.wh_field_name == "archived_field"


### PR DESCRIPTION
Be able to pass in _warehouse_name into Column, which gets set as the SQLAlchemy column name. This is useful for aliasing and when the variable name for the column needs to be different from the actual column name