### PR TITLE
add fieldsets parameters to benchling connection for validation

### DIFF
--- a/liminal/connection/benchling_connection.py
+++ b/liminal/connection/benchling_connection.py
@@ -30,6 +30,8 @@ class BenchlingConnection(BaseModel):
     warehouse_access: bool = False
         Whether your Benchling tenant has access to the warehouse. If warehouse_connection_string is provided, this will default to True.
         warehouse_access is required to set a custom warehouse names on entity schemas and their fields.
+    fieldsets: bool = False
+        Whether your Benchling tenant has access to fieldsets.
     """
 
     tenant_name: str
@@ -41,6 +43,7 @@ class BenchlingConnection(BaseModel):
     internal_api_admin_email: str | None = None
     internal_api_admin_password: str | None = None
     warehouse_access: bool = False
+    fieldsets: bool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -96,9 +96,11 @@ class CreateEntitySchema(BaseOperation):
             raise ValueError(
                 f"Entity schema warehouse name {self._validated_schema_properties.warehouse_name} already exists in Benchling."
             )
-        if self._validated_schema_properties.prefix in [
-            schema["prefix"] for schema in all_schemas
-        ]:
+        if (
+            not benchling_service.connection.fieldsets
+            and self._validated_schema_properties.prefix
+            in [schema["prefix"] for schema in all_schemas]
+        ):
             raise ValueError(
                 f"Entity schema prefix {self._validated_schema_properties.prefix} already exists in Benchling."
             )
@@ -235,9 +237,11 @@ class UpdateEntitySchema(BaseOperation):
             raise ValueError(
                 f"Entity schema warehouse name {self.update_props.warehouse_name} already exists in Benchling."
             )
-        if self.update_props.prefix and self.update_props.prefix in [
-            schema["prefix"] for schema in all_schemas
-        ]:
+        if (
+            not benchling_service.connection.fieldsets
+            and self.update_props.prefix
+            and self.update_props.prefix in [schema["prefix"] for schema in all_schemas]
+        ):
             raise ValueError(
                 f"Entity schema prefix {self.update_props.prefix} already exists in Benchling."
             )


### PR DESCRIPTION
Adds fieldsets parameter to benchling connection.

If fieldsets is set to true, it allows prefixes to be reused. This is a patch until full functionality around fieldsets is added to Liminal.

Ideally, the validation is more thorough and checks if schema is a part of a fieldset