### PR TITLE
Handle no schemas imported gracefully

### DIFF
--- a/liminal/dropdowns/compare.py
+++ b/liminal/dropdowns/compare.py
@@ -23,6 +23,10 @@ def compare_dropdowns(
     )
     processed_benchling_names = set()
     model_dropdowns = BaseDropdown.get_all_subclasses(dropdown_names)
+    if len(model_dropdowns) == 0 and len(benchling_dropdowns.keys()) > 0:
+        raise ValueError(
+            "No dropdown classes found that inherit from BaseDropdown. Ensure that the dropdown classes are defined and imported correctly."
+        )
     if dropdown_names:
         benchling_dropdowns = {
             name: benchling_dropdowns[name]

--- a/liminal/dropdowns/compare.py
+++ b/liminal/dropdowns/compare.py
@@ -1,3 +1,5 @@
+import logging
+
 from benchling_sdk.models import Dropdown
 
 from liminal.base.base_dropdown import BaseDropdown
@@ -13,6 +15,8 @@ from liminal.dropdowns.operations import (
 )
 from liminal.dropdowns.utils import get_benchling_dropdowns_dict
 
+LOGGER = logging.getLogger(__name__)
+
 
 def compare_dropdowns(
     benchling_service: BenchlingService, dropdown_names: set[str] | None = None
@@ -24,8 +28,8 @@ def compare_dropdowns(
     processed_benchling_names = set()
     model_dropdowns = BaseDropdown.get_all_subclasses(dropdown_names)
     if len(model_dropdowns) == 0 and len(benchling_dropdowns.keys()) > 0:
-        raise ValueError(
-            "No dropdown classes found that inherit from BaseDropdown. Ensure that the dropdown classes are defined and imported correctly."
+        LOGGER.warning(
+            "WARNING: No dropdown classes found that inherit from BaseDropdown. Ensure that the dropdown classes are defined and imported correctly."
         )
     if dropdown_names:
         benchling_dropdowns = {

--- a/liminal/entity_schemas/compare.py
+++ b/liminal/entity_schemas/compare.py
@@ -1,3 +1,5 @@
+import logging
+
 from liminal.base.compare_operation import CompareOperation
 from liminal.base.properties.base_field_properties import BaseFieldProperties
 from liminal.base.properties.base_name_template import BaseNameTemplate
@@ -19,6 +21,8 @@ from liminal.entity_schemas.utils import get_converted_tag_schemas
 from liminal.orm.base_model import BaseModel
 from liminal.orm.column import Column
 from liminal.utils import to_snake_case
+
+LOGGER = logging.getLogger(__name__)
 
 
 def compare_entity_schemas(
@@ -49,9 +53,10 @@ def compare_entity_schemas(
         if not m.__schema_properties__._archived
     ]
     if len(models) == 0 and len(benchling_schemas) > 0:
-        raise ValueError(
-            "No model classes found that inherit from BaseModel. Ensure that the model classes are defined and imported correctly."
+        LOGGER.warning(
+            "WARNING: No model classes found that inherit from BaseModel. Ensure that the model classes are defined and imported correctly."
         )
+
     archived_benchling_schema_wh_names = [
         s.warehouse_name for s, _, _ in benchling_schemas if s._archived is True
     ]

--- a/liminal/entity_schemas/compare.py
+++ b/liminal/entity_schemas/compare.py
@@ -48,6 +48,10 @@ def compare_entity_schemas(
         for m in BaseModel.get_all_subclasses(schema_names)
         if not m.__schema_properties__._archived
     ]
+    if len(models) == 0 and len(benchling_schemas) > 0:
+        raise ValueError(
+            "No model classes found that inherit from BaseModel. Ensure that the model classes are defined and imported correctly."
+        )
     archived_benchling_schema_wh_names = [
         s.warehouse_name for s, _, _ in benchling_schemas if s._archived is True
     ]


### PR DESCRIPTION
display a warning when no schemas are found locally but are found in Benchling. Usually an import error