### PR TITLE
allow liminal_validator functions to return an optional custom report

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ With your schemas defined in code, you can now take advantage of the additional 
     class Pizza(BaseModel, CustomEntityMixin):
         ...
 
-        @liminal_validator(ValidationSeverity.MED)
+        @liminal_validator
         def cook_time_and_temp_validator(self) -> None:
             if self.cook_time is not None and self.cook_temp is None:
                 raise ValueError("Cook temp is required if cook time is set")

--- a/docs/reference/validation.md
+++ b/docs/reference/validation.md
@@ -15,7 +15,7 @@ from liminal.validation import ValidationSeverity, liminal_validator
 class Pizza(BaseModel, CustomEntityMixin):
     ...
 
-    @liminal_validator(ValidationSeverity.MED)
+    @liminal_validator
     def cook_time_and_temp_validator(self) -> None:
         if self.cook_time is not None and self.cook_temp is None:
             raise ValueError("Cook temp is required if cook time is set")

--- a/liminal/validation/__init__.py
+++ b/liminal/validation/__init__.py
@@ -1,7 +1,7 @@
 import inspect
 from datetime import datetime
 from functools import wraps
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import BaseModel, ConfigDict
 
@@ -67,6 +67,7 @@ class BenchlingValidatorReport(BaseModel):
         entity: type["BenchlingBaseModel"],
         validator_name: str,
         message: str | None = None,
+        **kwargs: Any,
     ) -> "BenchlingValidatorReport":
         """Creates a BenchlingValidatorReport with the given parameters.
 
@@ -96,6 +97,7 @@ class BenchlingValidatorReport(BaseModel):
             creator_email=entity.creator.email if entity.creator else None,
             updated_date=entity.modified_at,
             message=message,
+            **kwargs,
         )
 
 


### PR DESCRIPTION
Some changes to the liminal_validator implementation./
- allows liminal_validator to return an optional custom ValidatorReport. This is useful for passing around kwargs and other information.
- allows `@liminal_validator` to be used without any arguments passed in. This uses partial and follows [this](https://stackoverflow.com/questions/653368/how-to-create-a-decorator-that-can-be-used-either-with-or-without-parameters)