### PR TITLE
translation link bugfix

### DIFF
--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -105,7 +105,7 @@ def generate_all_entity_schema_files(
                 if not has_date:
                     import_strings.append("from datetime import datetime")
             if (
-                col.type == BenchlingFieldType.get_entity_link_types()
+                col.type in BenchlingFieldType.get_entity_link_types()
                 and col.entity_link is not None
             ):
                 if not col.is_multi:

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -105,7 +105,7 @@ def generate_all_entity_schema_files(
                 if not has_date:
                     import_strings.append("from datetime import datetime")
             if (
-                col.type == BenchlingFieldType.ENTITY_LINK
+                col.type == BenchlingFieldType.get_entity_link_types()
                 and col.entity_link is not None
             ):
                 if not col.is_multi:

--- a/liminal/entity_schemas/tag_schema_models.py
+++ b/liminal/entity_schemas/tag_schema_models.py
@@ -164,7 +164,7 @@ class CreateTagSchemaFieldModel(BaseModel):
         )
 
         tagSchema = None
-        if new_props.type == BenchlingFieldType.ENTITY_LINK:
+        if new_props.type in BenchlingFieldType.get_entity_link_types():
             if new_props.entity_link is not None:
                 if benchling_service is None:
                     raise ValueError(

--- a/liminal/enums/benchling_field_type.py
+++ b/liminal/enums/benchling_field_type.py
@@ -32,3 +32,7 @@ class BenchlingFieldType(StrEnum):
             cls.DATE,
             cls.DATETIME,
         ]
+
+    @classmethod
+    def get_entity_link_types(cls) -> list[str]:
+        return [cls.ENTITY_LINK, cls.TRANSLATION_LINK]

--- a/liminal/mappers.py
+++ b/liminal/mappers.py
@@ -22,6 +22,8 @@ def convert_benchling_type_to_python_type(benchling_type: BenchlingFieldType) ->
         BenchlingFieldType.BLOB_LINK: dict[str, Any],
         BenchlingFieldType.CUSTOM_ENTITY_LINK: str,
         BenchlingFieldType.DNA_SEQUENCE_LINK: str,
+        BenchlingFieldType.AA_SEQUENCE_LINK: str,
+        BenchlingFieldType.TRANSLATION_LINK: str,
         BenchlingFieldType.DROPDOWN: str,
         BenchlingFieldType.ENTITY_LINK: str,
         BenchlingFieldType.ENTRY_LINK: str,
@@ -48,6 +50,8 @@ def convert_benchling_type_to_sql_alchemy_type(
         BenchlingFieldType.BLOB_LINK: JSON,
         BenchlingFieldType.CUSTOM_ENTITY_LINK: String,
         BenchlingFieldType.DNA_SEQUENCE_LINK: String,
+        BenchlingFieldType.AA_SEQUENCE_LINK: String,
+        BenchlingFieldType.TRANSLATION_LINK: String,
         BenchlingFieldType.DROPDOWN: String,
         BenchlingFieldType.ENTITY_LINK: String,
         BenchlingFieldType.ENTRY_LINK: String,
@@ -55,7 +59,6 @@ def convert_benchling_type_to_sql_alchemy_type(
         BenchlingFieldType.STORAGE_LINK: String,
         BenchlingFieldType.PART_LINK: String,
         BenchlingFieldType.MIXTURE_LINK: String,
-        BenchlingFieldType.AA_SEQUENCE_LINK: String,
         BenchlingFieldType.TEXT: String,
     }
     if benchling_type in benchling_to_sql_alchemy_type_map:
@@ -141,7 +144,7 @@ def convert_api_field_type_to_field_type(
         ): BenchlingFieldType.PART_LINK,
         (
             BenchlingAPIFieldType.TRANSLATION_LINK,
-            BenchlingFolderItemType.SEQUENCE,
+            None,
         ): BenchlingFieldType.TRANSLATION_LINK,
         (BenchlingAPIFieldType.FILE_LINK, None): BenchlingFieldType.ENTITY_LINK,
         (BenchlingAPIFieldType.FLOAT, None): BenchlingFieldType.DECIMAL,

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -73,10 +73,10 @@ class Column(SqlColumn):
             raise ValueError("Dropdown can only be set if the field type is DROPDOWN.")
         if dropdown is None and type == BenchlingFieldType.DROPDOWN:
             raise ValueError("Dropdown must be set if the field type is DROPDOWN.")
-        if entity_link and type != BenchlingFieldType.ENTITY_LINK:
-            raise ValueError(
-                "Entity link can only be set if the field type is ENTITY_LINK."
-            )
+        # if entity_link and type != BenchlingFieldType.ENTITY_LINK:
+        #     raise ValueError(
+        #         "Entity link can only be set if the field type is ENTITY_LINK."
+        #     )
         if parent_link and type != BenchlingFieldType.ENTITY_LINK:
             raise ValueError(
                 "Parent link can only be set if the field type is ENTITY_LINK."

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -73,19 +73,19 @@ class Column(SqlColumn):
             raise ValueError("Dropdown can only be set if the field type is DROPDOWN.")
         if dropdown is None and type == BenchlingFieldType.DROPDOWN:
             raise ValueError("Dropdown must be set if the field type is DROPDOWN.")
-        # if entity_link and type != BenchlingFieldType.ENTITY_LINK:
-        #     raise ValueError(
-        #         "Entity link can only be set if the field type is ENTITY_LINK."
-        #     )
-        if parent_link and type != BenchlingFieldType.ENTITY_LINK:
+        if entity_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
-                "Parent link can only be set if the field type is ENTITY_LINK."
+                "Entity link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
+            )
+        if parent_link and type not in BenchlingFieldType.get_entity_link_types():
+            raise ValueError(
+                "Parent link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
             )
         if type in BenchlingFieldType.get_non_multi_select_types() and is_multi is True:
             raise ValueError(f"Field type {type} cannot have multi-value set as True.")
         self.sqlalchemy_type = sqlalchemy_type
         foreign_key = None
-        if type == BenchlingFieldType.ENTITY_LINK and entity_link:
+        if type in BenchlingFieldType.get_entity_link_types() and entity_link:
             foreign_key = ForeignKey(f"{entity_link}$raw.id")
         if _warehouse_name:
             kwargs["name"] = _warehouse_name


### PR DESCRIPTION
Bug brought up [here](https://github.com/dynotx/liminal-orm/discussions/95): Fixes translation_link entity links around the codebase.

Previously, it was expected that translation_links to be have `folder_item_type=part_link`, which was found to be wrong.

Propagated this change around the code base to allow translation_links to be correctly configured as field entity_links.

Tested locally to ensure generate_files works and schemas are defined with no errors.

Test generate_files:
<img width="903" alt="Screenshot 2025-02-10 at 8 41 02 PM" src="https://github.com/user-attachments/assets/0778799e-ed93-4e6d-bcc8-7d2266e5b953" />

Test upgrade:
<img width="805" alt="Screenshot 2025-02-10 at 8 40 29 PM" src="https://github.com/user-attachments/assets/bc20e4d8-c1b1-4116-a27c-99987a8b35c4" />
