### PR TITLE
fix creating new entity schema with template based naming strategy

### DIFF
--- a/liminal/base/base_operation.py
+++ b/liminal/base/base_operation.py
@@ -13,13 +13,13 @@ Order of operations based on order class var:
     6. ArchiveDropdownOption
     7. ReorderDropdownOptions
     8. CreateSchema
-    9. UpdateSchema
-    10. UnarchiveSchema
-    11. CreateField
-    12. UnarchiveField
-    13. UpdateField
-    14. ArchiveField
-    15. UpdateEntitySchemaNameTemplate
+    9. UpdateEntitySchemaNameTemplate
+    10. UpdateSchema
+    11. UnarchiveSchema
+    12. CreateField
+    13. UnarchiveField
+    14. UpdateField
+    15. ArchiveField
     16. ReorderFields
     17. ArchiveSchema
     18. ArchiveDropdown

--- a/liminal/entity_schemas/compare.py
+++ b/liminal/entity_schemas/compare.py
@@ -327,10 +327,10 @@ def compare_entity_schemas(
             new_schema_props = BaseSchemaProperties()
             rollback_schema_props = BaseSchemaProperties()
             if model.__schema_properties__.warehouse_name != benchling_given_wh_name:
-                new_schema_props.warehouse_name = benchling_given_wh_name
-                rollback_schema_props.warehouse_name = (
+                new_schema_props.warehouse_name = (
                     model.__schema_properties__.warehouse_name
                 )
+                rollback_schema_props.warehouse_name = benchling_given_wh_name
             if template_based_naming_strategies:
                 new_schema_props.naming_strategies = template_based_naming_strategies
                 rollback_schema_props.naming_strategies = (

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -162,7 +162,7 @@ class ArchiveEntitySchema(BaseOperation):
 
 
 class UnarchiveEntitySchema(BaseOperation):
-    order: ClassVar[int] = 100
+    order: ClassVar[int] = 110
 
     def __init__(self, wh_schema_name: str) -> None:
         self.wh_schema_name = wh_schema_name
@@ -187,7 +187,7 @@ class UnarchiveEntitySchema(BaseOperation):
 
 
 class UpdateEntitySchema(BaseOperation):
-    order: ClassVar[int] = 90
+    order: ClassVar[int] = 100
 
     def __init__(
         self,
@@ -251,7 +251,7 @@ class UpdateEntitySchema(BaseOperation):
 
 
 class UpdateEntitySchemaNameTemplate(BaseOperation):
-    order: ClassVar[int] = 150
+    order: ClassVar[int] = 90
 
     def __init__(
         self,
@@ -283,7 +283,7 @@ class UpdateEntitySchemaNameTemplate(BaseOperation):
 
 
 class CreateEntitySchemaField(BaseOperation):
-    order: ClassVar[int] = 110
+    order: ClassVar[int] = 120
 
     def __init__(
         self,
@@ -370,7 +370,7 @@ class CreateEntitySchemaField(BaseOperation):
 
 
 class ArchiveEntitySchemaField(BaseOperation):
-    order: ClassVar[int] = 140
+    order: ClassVar[int] = 150
 
     def __init__(
         self, wh_schema_name: str, wh_field_name: str, index: int | None = None
@@ -421,7 +421,7 @@ class ArchiveEntitySchemaField(BaseOperation):
 
 
 class UnarchiveEntitySchemaField(BaseOperation):
-    order: ClassVar[int] = 120
+    order: ClassVar[int] = 130
 
     def __init__(
         self, wh_schema_name: str, wh_field_name: str, index: int | None = None
@@ -468,7 +468,7 @@ class UnarchiveEntitySchemaField(BaseOperation):
 
 
 class UpdateEntitySchemaField(BaseOperation):
-    order: ClassVar[int] = 130
+    order: ClassVar[int] = 140
 
     def __init__(
         self,


### PR DESCRIPTION
This fixes a bug when creating a new entity schema with a name template and template based naming strategy. 3 operations are needed in the correct order as shown below

<img width="924" alt="Screenshot 2025-02-10 at 9 08 10 PM" src="https://github.com/user-attachments/assets/370cc7eb-43f5-4926-81be-ca54463c3598" />

<img width="1399" alt="Screenshot 2025-02-10 at 9 08 20 PM" src="https://github.com/user-attachments/assets/af475676-0842-4492-97eb-23827c251add" />
