### PR TITLE
implement sequence constraint logic constraints

### DIFF
--- a/docs/reference/entity-schemas.md
+++ b/docs/reference/entity-schemas.md
@@ -112,7 +112,11 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
 
 - **constraint_fields: set[str] | None**
 
-    Set of constraints for field values for the schema. Must be a set of column names that specify that their values must be a unique combination within an entity. If the entity type is a Sequence, "bases" can be a constraint field.
+    Set of constraints for field values for the schema. Must be a set of warehouse column names. This specifies that their entity field values must be a unique combination within an entity.
+    The following sequence constraints are also supported:
+    - `'bases'`: only supported for nucleotide sequence entity types. hasUniqueResidues=True
+    - `'amino_acids_ignore_case'`: only supported for amino acid sequence entity types. hasUniqueResidues=True
+    - `'amino_acids_exact_match'`: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
 
 - **_archived: bool | None = None**
 

--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -66,8 +66,7 @@ class BaseSchemaProperties(BaseModel):
     include_registry_id_in_chips : bool | None = None
         Flag for configuring the chip label for entities. Determines if the chip will include the Registry ID in the chip label.
     constraint_fields : set[str] | None
-        Set of constraints for field values for the schema. Must be a set of column names that specify that their values must be a unique combination within an entity.
-        If the entity type is a Sequence, "bases" can be a constraint field.
+        Set of constraints for field values for the schema. Must be a set of warehouse column names. This specifies that their entity field values must be a unique combination within an entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """

--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -67,6 +67,10 @@ class BaseSchemaProperties(BaseModel):
         Flag for configuring the chip label for entities. Determines if the chip will include the Registry ID in the chip label.
     constraint_fields : set[str] | None
         Set of constraints for field values for the schema. Must be a set of warehouse column names. This specifies that their entity field values must be a unique combination within an entity.
+        The following sequence constraints are also supported:
+        - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
+        - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
+        - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -39,7 +39,7 @@ class CreateEntitySchema(BaseOperation):
         self.schema_properties = schema_properties
         self.fields = fields
         self._validated_schema_properties = SchemaProperties(
-            **schema_properties.model_dump()
+            **schema_properties.model_dump(exclude_unset=True)
         )
 
     def execute(self, benchling_service: BenchlingService) -> dict[str, Any]:

--- a/liminal/enums/__init__.py
+++ b/liminal/enums/__init__.py
@@ -5,3 +5,4 @@ from liminal.enums.benchling_field_type import BenchlingFieldType
 from liminal.enums.benchling_folder_item_type import BenchlingFolderItemType
 from liminal.enums.benchling_naming_strategy import BenchlingNamingStrategy
 from liminal.enums.benchling_sequence_type import BenchlingSequenceType
+from liminal.enums.sequence_constraint import SequenceConstraint

--- a/liminal/enums/benchling_entity_type.py
+++ b/liminal/enums/benchling_entity_type.py
@@ -14,7 +14,7 @@ class BenchlingEntityType(StrEnum):
     MIXTURE = "mixture"
     MOLECULE = "molecule"
 
-    def is_sequence(self) -> bool:
+    def is_nt_sequence(self) -> bool:
         return self in [
             self.DNA_SEQUENCE,
             self.RNA_SEQUENCE,

--- a/liminal/enums/sequence_constraint.py
+++ b/liminal/enums/sequence_constraint.py
@@ -1,0 +1,13 @@
+from liminal.base.str_enum import StrEnum
+
+
+class SequenceConstraint(StrEnum):
+    """This enum represents hardcoded sequence constraints."""
+
+    BASES = "bases"
+    AMINO_ACIDS_IGNORE_CASE = "amino_acids_ignore_case"
+    AMINO_ACIDS_EXACT_MATCH = "amino_acids_exact_match"
+
+    @classmethod
+    def is_sequence_constraint(cls, constraint: str) -> bool:
+        return constraint in cls._value2member_map_

--- a/liminal/orm/schema_properties.py
+++ b/liminal/orm/schema_properties.py
@@ -35,9 +35,8 @@ class SchemaProperties(BaseSchemaProperties):
         Flag for configuring the chip label for entities. Determines if the chip will use the Registry ID as the main label for items.
     include_registry_id_in_chips : bool | None = None
         Flag for configuring the chip label for entities. Determines if the chip will include the Registry ID in the chip label.
-    constraint_fields : set[str] | None
-        Set of constraints for field values for the schema. Must be a set of column names that specify that their values must be a unique combination within an entity.
-        If the entity type is a Sequence, "bases" can be a constraint field.
+    constraint_fields : set[str]
+        Set of constraints for field values for the schema. Must be a set of warehouse column names. This specifies that their entity field values must be a unique combination within an entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """
@@ -50,7 +49,7 @@ class SchemaProperties(BaseSchemaProperties):
     use_registry_id_as_label: bool | None = False
     include_registry_id_in_chips: bool | None = False
     mixture_schema_config: MixtureSchemaConfig | None = None
-    constraint_fields: set[str] | None = None
+    constraint_fields: set[str] = set()
     _archived: bool = False
 
     def __init__(self, **data: Any):

--- a/liminal/orm/schema_properties.py
+++ b/liminal/orm/schema_properties.py
@@ -37,6 +37,10 @@ class SchemaProperties(BaseSchemaProperties):
         Flag for configuring the chip label for entities. Determines if the chip will include the Registry ID in the chip label.
     constraint_fields : set[str]
         Set of constraints for field values for the schema. Must be a set of warehouse column names. This specifies that their entity field values must be a unique combination within an entity.
+        The following sequence constraints are also supported:
+        - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
+        - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
+        - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """


### PR DESCRIPTION
When originally implementing entity schema constraints, we made some incorrect assumptions for how sequence constraints should be implemented. This corrects this logic across the codebase.

"bases": only for nt sequence entity types
"amino_acids_ignore_case" and "amino_acids_exact_match": only for aa sequences
- only one sequence constraint allowed in constraints

**Screenshots of testing**
- Only one sequence constraint allowed in constraints
<img width="622" alt="Screenshot 2025-02-11 at 7 13 48 PM" src="https://github.com/user-attachments/assets/92c78ebf-85c3-4299-ae8a-c7630ab425b0" />
<img width="668" alt="Screenshot 2025-02-11 at 7 13 53 PM" src="https://github.com/user-attachments/assets/8338ff51-fb46-461c-b2c4-6f7f133ec10c" />
- Upgrade/Downgrade
<img width="798" alt="Screenshot 2025-02-11 at 7 46 42 PM" src="https://github.com/user-attachments/assets/36638633-57d4-4c8e-968b-fb30fcbde33a" />
<img width="668" alt="Screenshot 2025-02-11 at 7 13 53 PM" src="https://github.com/user-attachments/assets/8d874196-619f-482f-b9b2-356a9e586b68" />
