### PR TITLE
part link in mappers

### DIFF
--- a/liminal/enums/benchling_field_type.py
+++ b/liminal/enums/benchling_field_type.py
@@ -35,4 +35,4 @@ class BenchlingFieldType(StrEnum):
 
     @classmethod
     def get_entity_link_types(cls) -> list[str]:
-        return [cls.ENTITY_LINK, cls.TRANSLATION_LINK]
+        return [cls.ENTITY_LINK, cls.TRANSLATION_LINK, cls.PART_LINK]

--- a/liminal/mappers.py
+++ b/liminal/mappers.py
@@ -91,13 +91,10 @@ def convert_field_type_to_api_field_type(
             BenchlingAPIFieldType.FILE_LINK,
             BenchlingFolderItemType.SEQUENCE,
         ),
-        BenchlingFieldType.PART_LINK: (
-            BenchlingAPIFieldType.PART_LINK,
-            BenchlingFolderItemType.SEQUENCE,
-        ),
+        BenchlingFieldType.PART_LINK: (BenchlingAPIFieldType.PART_LINK, None),
         BenchlingFieldType.TRANSLATION_LINK: (
             BenchlingAPIFieldType.TRANSLATION_LINK,
-            BenchlingFolderItemType.SEQUENCE,
+            None,
         ),
         BenchlingFieldType.ENTITY_LINK: (BenchlingAPIFieldType.FILE_LINK, None),
         BenchlingFieldType.DECIMAL: (BenchlingAPIFieldType.FLOAT, None),
@@ -138,10 +135,7 @@ def convert_api_field_type_to_field_type(
             BenchlingAPIFieldType.FILE_LINK,
             BenchlingFolderItemType.PROTEIN,
         ): BenchlingFieldType.AA_SEQUENCE_LINK,
-        (
-            BenchlingAPIFieldType.PART_LINK,
-            BenchlingFolderItemType.SEQUENCE,
-        ): BenchlingFieldType.PART_LINK,
+        (BenchlingAPIFieldType.PART_LINK, None): BenchlingFieldType.PART_LINK,
         (
             BenchlingAPIFieldType.TRANSLATION_LINK,
             None,

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -75,11 +75,11 @@ class Column(SqlColumn):
             raise ValueError("Dropdown must be set if the field type is DROPDOWN.")
         if entity_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
-                "Entity link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
+                f"Entity link can only be set if the field type is one of {BenchlingFieldType.get_entity_link_types()}."
             )
         if parent_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
-                "Parent link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
+                f"Parent link can only be set if the field type is one of {BenchlingFieldType.get_entity_link_types()}."
             )
         if type in BenchlingFieldType.get_non_multi_select_types() and is_multi is True:
             raise ValueError(f"Field type {type} cannot have multi-value set as True.")


### PR DESCRIPTION
This PR fixes the error below where PART_LINK was not defined properly in Liminal as a field type.

> ValueError: Field type 'BenchlingAPIFieldType.PART_LINK' is not supported.

Tests:
![Screenshot 2025-02-17 at 5 51 05 PM](https://github.com/user-attachments/assets/529898e9-b359-45bc-82cb-5b0575030c85)
<img width="933" alt="Screenshot 2025-02-17 at 8 20 32 AM" src="https://github.com/user-attachments/assets/1ac1254e-d4d2-4317-a7ad-a584fa9e2e48" />
