### PR TITLE
Show bases in expanded view

### DIFF
--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -71,6 +71,8 @@ class BaseSchemaProperties(BaseModel):
         - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
         - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
         - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
+    show_bases_in_expanded_view : bool | None
+        Whether the bases should be shown in the expanded view of the entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """
@@ -84,6 +86,7 @@ class BaseSchemaProperties(BaseModel):
     use_registry_id_as_label: bool | None = None
     include_registry_id_in_chips: bool | None = None
     constraint_fields: set[str] | None = None
+    show_bases_in_expanded_view: bool | None = None
     _archived: bool | None = None
 
     def __init__(self, **data: Any):

--- a/liminal/entity_schemas/entity_schema_models.py
+++ b/liminal/entity_schemas/entity_schema_models.py
@@ -152,6 +152,7 @@ class CreateEntitySchemaModel(BaseModel):
     useOrganizationCollectionAliasForDisplayLabel: bool | None = None
     labelingStrategies: list[str] | None = None
     constraint: EntitySchemaConstraint | None = None
+    showResidues: bool | None = None
 
     @classmethod
     def from_benchling_props(
@@ -185,6 +186,7 @@ class CreateEntitySchemaModel(BaseModel):
             includeRegistryIdInChips=benchling_props.include_registry_id_in_chips,
             useOrganizationCollectionAliasForDisplayLabel=benchling_props.use_registry_id_as_label,
             labelingStrategies=[s.value for s in benchling_props.naming_strategies],
+            showResidues=benchling_props.show_bases_in_expanded_view,
             constraint=EntitySchemaConstraint.from_constraint_fields(
                 benchling_props.constraint_fields
             ),

--- a/liminal/entity_schemas/tag_schema_models.py
+++ b/liminal/entity_schemas/tag_schema_models.py
@@ -452,6 +452,8 @@ class TagSchemaModel(BaseModel):
             )
         if "include_registry_id_in_chips" in update_diff_names:
             self.includeRegistryIdInChips = update_props.include_registry_id_in_chips
+        if "show_bases_in_expanded_view" in update_diff_names:
+            self.showResidues = update_props.show_bases_in_expanded_view
 
         if "constraint_fields" in update_diff_names:
             if update_props.constraint_fields:

--- a/liminal/entity_schemas/utils.py
+++ b/liminal/entity_schemas/utils.py
@@ -88,6 +88,7 @@ def convert_tag_schema_to_internal_schema(
             _archived=tag_schema.archiveRecord is not None,
             use_registry_id_as_label=tag_schema.useOrganizationCollectionAliasForDisplayLabel,
             include_registry_id_in_chips=tag_schema.includeRegistryIdInChips,
+            show_bases_in_expanded_view=tag_schema.showResidues,
         ),
         NameTemplate(
             parts=tag_schema.get_internal_name_template_parts(),

--- a/liminal/enums/benchling_entity_type.py
+++ b/liminal/enums/benchling_entity_type.py
@@ -21,3 +21,12 @@ class BenchlingEntityType(StrEnum):
             self.DNA_OLIGO,
             self.RNA_OLIGO,
         ]
+
+    def is_sequence(self) -> bool:
+        return self in [
+            self.DNA_SEQUENCE,
+            self.RNA_SEQUENCE,
+            self.DNA_OLIGO,
+            self.RNA_OLIGO,
+            self.AA_SEQUENCE,
+        ]

--- a/liminal/enums/benchling_field_type.py
+++ b/liminal/enums/benchling_field_type.py
@@ -35,4 +35,4 @@ class BenchlingFieldType(StrEnum):
 
     @classmethod
     def get_entity_link_types(cls) -> list[str]:
-        return [cls.ENTITY_LINK, cls.TRANSLATION_LINK]
+        return [cls.ENTITY_LINK, cls.TRANSLATION_LINK, cls.PART_LINK]

--- a/liminal/mappers.py
+++ b/liminal/mappers.py
@@ -91,13 +91,10 @@ def convert_field_type_to_api_field_type(
             BenchlingAPIFieldType.FILE_LINK,
             BenchlingFolderItemType.SEQUENCE,
         ),
-        BenchlingFieldType.PART_LINK: (
-            BenchlingAPIFieldType.PART_LINK,
-            BenchlingFolderItemType.SEQUENCE,
-        ),
+        BenchlingFieldType.PART_LINK: (BenchlingAPIFieldType.PART_LINK, None),
         BenchlingFieldType.TRANSLATION_LINK: (
             BenchlingAPIFieldType.TRANSLATION_LINK,
-            BenchlingFolderItemType.SEQUENCE,
+            None,
         ),
         BenchlingFieldType.ENTITY_LINK: (BenchlingAPIFieldType.FILE_LINK, None),
         BenchlingFieldType.DECIMAL: (BenchlingAPIFieldType.FLOAT, None),
@@ -138,10 +135,7 @@ def convert_api_field_type_to_field_type(
             BenchlingAPIFieldType.FILE_LINK,
             BenchlingFolderItemType.PROTEIN,
         ): BenchlingFieldType.AA_SEQUENCE_LINK,
-        (
-            BenchlingAPIFieldType.PART_LINK,
-            BenchlingFolderItemType.SEQUENCE,
-        ): BenchlingFieldType.PART_LINK,
+        (BenchlingAPIFieldType.PART_LINK, None): BenchlingFieldType.PART_LINK,
         (
             BenchlingAPIFieldType.TRANSLATION_LINK,
             None,

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -75,11 +75,11 @@ class Column(SqlColumn):
             raise ValueError("Dropdown must be set if the field type is DROPDOWN.")
         if entity_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
-                "Entity link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
+                f"Entity link can only be set if the field type is one of {BenchlingFieldType.get_entity_link_types()}."
             )
         if parent_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
-                "Parent link can only be set if the field type is ENTITY_LINK or TRANSLATION_LINK."
+                f"Parent link can only be set if the field type is one of {BenchlingFieldType.get_entity_link_types()}."
             )
         if type in BenchlingFieldType.get_non_multi_select_types() and is_multi is True:
             raise ValueError(f"Field type {type} cannot have multi-value set as True.")

--- a/liminal/orm/schema_properties.py
+++ b/liminal/orm/schema_properties.py
@@ -41,6 +41,8 @@ class SchemaProperties(BaseSchemaProperties):
         - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
         - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
         - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
+    show_bases_in_expanded_view : bool | None = None
+        Whether the bases should be shown in the expanded view of the entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """
@@ -54,6 +56,7 @@ class SchemaProperties(BaseSchemaProperties):
     include_registry_id_in_chips: bool | None = False
     mixture_schema_config: MixtureSchemaConfig | None = None
     constraint_fields: set[str] = set()
+    show_bases_in_expanded_view: bool | None = False
     _archived: bool = False
 
     def __init__(self, **data: Any):
@@ -76,7 +79,10 @@ class SchemaProperties(BaseSchemaProperties):
             raise ValueError(
                 "The entity type is not a Mixture. Remove the mixture schema config."
             )
-
+        if not self.entity_type.is_sequence() and self.show_bases_in_expanded_view:
+            raise ValueError(
+                "show_bases_in_expanded_view can only be set for sequence entities."
+            )
         if self.naming_strategies and len(self.naming_strategies) == 0:
             raise ValueError(
                 "Schema must have at least 1 registry naming option enabled"


### PR DESCRIPTION
Adds coverage for "show_bases_in_expanded_view", or showResidues according to Benchling's API.
<img width="559" alt="Screenshot 2025-02-17 at 6 18 43 PM" src="https://github.com/user-attachments/assets/3a8e28e0-1b76-48f6-8e34-d081bcb2c042" />
![Screenshot 2025-02-17 at 6 17 42 PM](https://github.com/user-attachments/assets/96cd658d-0b62-4b80-964b-f3f4482347db)
