### PR TITLE
cover unit aware fields

### DIFF
--- a/docs/reference/entity-schemas.md
+++ b/docs/reference/entity-schemas.md
@@ -40,7 +40,7 @@ class Pizza(BaseModel, CustomEntityMixin):
 
     dough = Column(name="dough", type=BenchlingFieldType.ENTITY_LINK, required=True, entity_link="dough")
     cook_temp = Column(name="cook_temp", type=BenchlingFieldType.INTEGER, required=False)
-    cook_time = Column(name="cook_time", type=BenchlingFieldType.INTEGER, required=False)
+    cook_time = Column(name="cook_time", type=BenchlingFieldType.INTEGER, required=False, unit_name"second")
     toppings = Column(name="toppings", type=BenchlingFieldType.DROPDOWN, required=False, dropdown=Toppings)
     customer_review = Column(name="customer_review", type=BenchlingFieldType.INTEGER, required=False)
     slices = Column(name="slices", type=BenchlingFieldType.ENTITY_LINK, required=False, is_multi=True, entity_link="slice")
@@ -118,6 +118,10 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
     - `'amino_acids_ignore_case'`: only supported for amino acid sequence entity types. hasUniqueResidues=True
     - `'amino_acids_exact_match'`: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
 
+- **show_bases_in_expanded_view: bool | None = None**
+
+    Whether the bases should be shown in the expanded view of the entity.
+
 - **_archived: bool | None = None**
 
     Private attribute used to set the archived status of the schema.
@@ -168,6 +172,17 @@ All Liminal entity schema classes must inherit from one of the mixins in the [mi
 - **entity_link: str | None = None**
 
     The entity link for the field. The entity link must be the `warehouse_name` as a string of the entity schema that the field is linking to. The type of the Column must be `BenchlingFieldType.ENTITY_LINK` in order to be valid. Defaults to None.
+
+- **unit_name: str | None = None**
+
+    The unit name for the field. Defaults to None.
+
+    !!! warning
+        Once the unit is set on a field, it CANNOT be changed. Benchling's recommendation is to archive the field and create a new one if you need to change the unit.
+
+- **decimal_places: int | None = None**
+
+    The number of decimal places for the field. Must be an integer between 0 and 15. Defaults to None.
 
 - **_archived: bool = False**
 

--- a/liminal/base/properties/base_field_properties.py
+++ b/liminal/base/properties/base_field_properties.py
@@ -49,6 +49,8 @@ class BaseFieldProperties(BaseModel):
     dropdown_link: str | None = None
     entity_link: str | None = None
     tooltip: str | None = None
+    decimal_places: int | None = None
+    unit_name: str | None = None
     _archived: bool | None = PrivateAttr(default=None)
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -122,4 +124,4 @@ class BaseFieldProperties(BaseModel):
 
     def __repr__(self) -> str:
         """Generates a string representation of the class so that it can be executed."""
-        return f"{self.__class__.__name__}({', '.join([f'{k}={v.__repr__()}' for k, v in self.model_dump(exclude_unset=True, exclude_defaults=True).items()])})"
+        return f"{self.__class__.__name__}({', '.join([f'{k}={v.__repr__()}' for k, v in self.model_dump(exclude_unset=True).items()])})"

--- a/liminal/base/properties/base_schema_properties.py
+++ b/liminal/base/properties/base_schema_properties.py
@@ -71,6 +71,8 @@ class BaseSchemaProperties(BaseModel):
         - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
         - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
         - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
+    show_bases_in_expanded_view : bool | None
+        Whether the bases should be shown in the expanded view of the entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """
@@ -84,6 +86,7 @@ class BaseSchemaProperties(BaseModel):
     use_registry_id_as_label: bool | None = None
     include_registry_id_in_chips: bool | None = None
     constraint_fields: set[str] | None = None
+    show_bases_in_expanded_view: bool | None = None
     _archived: bool | None = None
 
     def __init__(self, **data: Any):

--- a/liminal/entity_schemas/entity_schema_models.py
+++ b/liminal/entity_schemas/entity_schema_models.py
@@ -162,6 +162,7 @@ class CreateEntitySchemaModel(BaseModel):
     useOrganizationCollectionAliasForDisplayLabel: bool | None = None
     labelingStrategies: list[str] | None = None
     constraint: EntitySchemaConstraint | None = None
+    showResidues: bool | None = None
 
     @classmethod
     def from_benchling_props(
@@ -195,6 +196,7 @@ class CreateEntitySchemaModel(BaseModel):
             includeRegistryIdInChips=benchling_props.include_registry_id_in_chips,
             useOrganizationCollectionAliasForDisplayLabel=benchling_props.use_registry_id_as_label,
             labelingStrategies=[s.value for s in benchling_props.naming_strategies],
+            showResidues=benchling_props.show_bases_in_expanded_view,
             constraint=EntitySchemaConstraint.from_constraint_fields(
                 benchling_props.constraint_fields
             ),

--- a/liminal/entity_schemas/entity_schema_models.py
+++ b/liminal/entity_schemas/entity_schema_models.py
@@ -12,6 +12,7 @@ from liminal.enums import BenchlingEntityType
 from liminal.enums.sequence_constraint import SequenceConstraint
 from liminal.mappers import convert_field_type_to_api_field_type
 from liminal.orm.schema_properties import MixtureSchemaConfig, SchemaProperties
+from liminal.unit_dictionary.utils import get_unit_id_from_name
 
 
 class FieldLinkShortModel(BaseModel):
@@ -80,6 +81,8 @@ class CreateEntitySchemaFieldModel(BaseModel):
     isParentLink: bool = False
     dropdownId: str | None = None
     link: FieldLinkShortModel | None = None
+    unitId: str | None = None
+    decimalPrecision: int | None = None
 
     @classmethod
     def from_benchling_props(
@@ -124,6 +127,11 @@ class CreateEntitySchemaFieldModel(BaseModel):
             dropdown_summary_id = get_benchling_dropdown_summary_by_name(
                 benchling_service, field_props.dropdown_link
             ).id
+        unit_id = None
+        if field_props.unit_name is not None:
+            if benchling_service is None:
+                raise ValueError("Benchling SDK must be provided to update unit field.")
+            unit_id = get_unit_id_from_name(benchling_service, field_props.unit_name)
         return CreateEntitySchemaFieldModel(
             name=field_props.name,
             systemName=field_props.warehouse_name,
@@ -135,6 +143,8 @@ class CreateEntitySchemaFieldModel(BaseModel):
             link=FieldLinkShortModel(
                 tagSchema=tag_schema, folderItemType=folder_item_type
             ),
+            unitId=unit_id,
+            decimalPrecision=field_props.decimal_places,
         )
 
 

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -91,7 +91,7 @@ def generate_all_entity_schema_files(
                 dropdown_classname = dropdown_name_to_classname_map[col.dropdown_link]
                 dropdowns.append(dropdown_classname)
             column_strings.append(
-                f"""{tab}{col_name}: SqlColumn = Column(name="{col.name}", type={str(col.type)}, required={col.required}{', is_multi=True' if col.is_multi else ''}{', parent_link=True' if col.parent_link else ''}{f', entity_link="{col.entity_link}"' if col.entity_link else ''}{f', dropdown={dropdown_classname}' if dropdown_classname else ''}{f', tooltip="{col.tooltip}"' if col.tooltip else ''})"""
+                f"""{tab}{col_name}: SqlColumn = Column(name="{col.name}", type={str(col.type)}, required={col.required}{', is_multi=True' if col.is_multi else ''}{', parent_link=True' if col.parent_link else ''}{f', entity_link="{col.entity_link}"' if col.entity_link else ''}{f', dropdown={dropdown_classname}' if dropdown_classname else ''}{f', tooltip="{col.tooltip}"' if col.tooltip else ''}{f', unit_name="{col.unit_name}"' if col.unit_name else ''}{f', decimal_places={col.decimal_places}' if col.decimal_places else ''})"""
             )
             if col.required and col.type:
                 init_strings.append(

--- a/liminal/entity_schemas/tag_schema_models.py
+++ b/liminal/entity_schemas/tag_schema_models.py
@@ -490,6 +490,8 @@ class TagSchemaModel(BaseModel):
             )
         if "include_registry_id_in_chips" in update_diff_names:
             self.includeRegistryIdInChips = update_props.include_registry_id_in_chips
+        if "show_bases_in_expanded_view" in update_diff_names:
+            self.showResidues = update_props.show_bases_in_expanded_view
 
         if "constraint_fields" in update_diff_names:
             if update_props.constraint_fields:

--- a/liminal/entity_schemas/utils.py
+++ b/liminal/entity_schemas/utils.py
@@ -13,6 +13,7 @@ from liminal.mappers import (
 )
 from liminal.orm.name_template import NameTemplate
 from liminal.orm.schema_properties import MixtureSchemaConfig, SchemaProperties
+from liminal.unit_dictionary.utils import get_unit_id_to_name_map
 
 
 def get_converted_tag_schemas(
@@ -26,6 +27,7 @@ def get_converted_tag_schemas(
     """
     all_schemas = TagSchemaModel.get_all(benchling_service, wh_schema_names)
     dropdowns_map = get_benchling_dropdown_id_name_map(benchling_service)
+    unit_id_to_name_map = get_unit_id_to_name_map(benchling_service)
     all_schemas = (
         all_schemas
         if include_archived
@@ -33,7 +35,7 @@ def get_converted_tag_schemas(
     )
     return [
         convert_tag_schema_to_internal_schema(
-            tag_schema, dropdowns_map, include_archived
+            tag_schema, dropdowns_map, unit_id_to_name_map, include_archived
         )
         for tag_schema in all_schemas
     ]
@@ -42,6 +44,7 @@ def get_converted_tag_schemas(
 def convert_tag_schema_to_internal_schema(
     tag_schema: TagSchemaModel,
     dropdowns_map: dict[str, str],
+    unit_id_to_name_map: dict[str, str],
     include_archived_fields: bool = False,
 ) -> tuple[SchemaProperties, NameTemplate, dict[str, BaseFieldProperties]]:
     all_fields = tag_schema.allFields
@@ -94,14 +97,18 @@ def convert_tag_schema_to_internal_schema(
             order_name_parts_by_sequence=tag_schema.shouldOrderNamePartsBySequence,
         ),
         {
-            f.systemName: convert_tag_schema_field_to_field_properties(f, dropdowns_map)
+            f.systemName: convert_tag_schema_field_to_field_properties(
+                f, dropdowns_map, unit_id_to_name_map
+            )
             for f in all_fields
         },
     )
 
 
 def convert_tag_schema_field_to_field_properties(
-    field: TagSchemaFieldModel, dropdowns_map: dict[str, str]
+    field: TagSchemaFieldModel,
+    dropdowns_map: dict[str, str],
+    unit_id_to_name_map: dict[str, str],
 ) -> BaseFieldProperties:
     return BaseFieldProperties(
         name=field.name,
@@ -120,6 +127,10 @@ def convert_tag_schema_field_to_field_properties(
         else None,
         tooltip=field.tooltipText,
         _archived=field.archiveRecord is not None,
+        unit_name=unit_id_to_name_map.get(field.unitApiIdentifier)
+        if field.unitApiIdentifier
+        else None,
+        decimal_places=field.decimalPrecision,
     )
 
 

--- a/liminal/entity_schemas/utils.py
+++ b/liminal/entity_schemas/utils.py
@@ -91,6 +91,7 @@ def convert_tag_schema_to_internal_schema(
             _archived=tag_schema.archiveRecord is not None,
             use_registry_id_as_label=tag_schema.useOrganizationCollectionAliasForDisplayLabel,
             include_registry_id_in_chips=tag_schema.includeRegistryIdInChips,
+            show_bases_in_expanded_view=tag_schema.showResidues,
         ),
         NameTemplate(
             parts=tag_schema.get_internal_name_template_parts(),

--- a/liminal/enums/benchling_entity_type.py
+++ b/liminal/enums/benchling_entity_type.py
@@ -21,3 +21,12 @@ class BenchlingEntityType(StrEnum):
             self.DNA_OLIGO,
             self.RNA_OLIGO,
         ]
+
+    def is_sequence(self) -> bool:
+        return self in [
+            self.DNA_SEQUENCE,
+            self.RNA_SEQUENCE,
+            self.DNA_OLIGO,
+            self.RNA_OLIGO,
+            self.AA_SEQUENCE,
+        ]

--- a/liminal/enums/benchling_field_type.py
+++ b/liminal/enums/benchling_field_type.py
@@ -36,3 +36,7 @@ class BenchlingFieldType(StrEnum):
     @classmethod
     def get_entity_link_types(cls) -> list[str]:
         return [cls.ENTITY_LINK, cls.TRANSLATION_LINK, cls.PART_LINK]
+
+    @classmethod
+    def get_number_field_types(cls) -> list[str]:
+        return [cls.INTEGER, cls.DECIMAL]

--- a/liminal/orm/column.py
+++ b/liminal/orm/column.py
@@ -32,6 +32,10 @@ class Column(SqlColumn):
         The dropdown for the field.
     entity_link : str | None = None
         The warehouse name of the entity the field links to.
+    unit : str | None = None
+        The unit of the field. Searches for the unit warehouse name in the Unit Dictionary.
+    decimal_places : int | None = None
+        The number of decimal places for the field. Must be (0-15).
     _warehouse_name : str | None = None
         The warehouse name of the column. Necessary when the variable name is not the same as the warehouse name.
     _archived : bool = False
@@ -48,6 +52,8 @@ class Column(SqlColumn):
         tooltip: str | None = None,
         dropdown: Type[BaseDropdown] | None = None,  # noqa: UP006
         entity_link: str | None = None,
+        unit_name: str | None = None,
+        decimal_places: int | None = None,
         _warehouse_name: str | None = None,
         _archived: bool = False,
         **kwargs: Any,
@@ -64,6 +70,8 @@ class Column(SqlColumn):
             entity_link=entity_link,
             tooltip=tooltip,
             _archived=_archived,
+            unit_name=unit_name,
+            decimal_places=decimal_places,
         )
         self.properties = properties
 
@@ -73,6 +81,16 @@ class Column(SqlColumn):
             raise ValueError("Dropdown can only be set if the field type is DROPDOWN.")
         if dropdown is None and type == BenchlingFieldType.DROPDOWN:
             raise ValueError("Dropdown must be set if the field type is DROPDOWN.")
+        if unit_name and type not in BenchlingFieldType.get_number_field_types():
+            raise ValueError(
+                f"Unit can only be set if the field type is one of {BenchlingFieldType.get_number_field_types()}."
+            )
+        if decimal_places and type not in BenchlingFieldType.DECIMAL:
+            raise ValueError(
+                "Decimal places can only be set if the field type is DECIMAL."
+            )
+        if decimal_places and (decimal_places < 0 or decimal_places > 15):
+            raise ValueError("Decimal places must be between 0 and 15.")
         if entity_link and type not in BenchlingFieldType.get_entity_link_types():
             raise ValueError(
                 f"Entity link can only be set if the field type is one of {BenchlingFieldType.get_entity_link_types()}."

--- a/liminal/orm/schema_properties.py
+++ b/liminal/orm/schema_properties.py
@@ -41,6 +41,8 @@ class SchemaProperties(BaseSchemaProperties):
         - bases: only supported for nucleotide sequence entity types. hasUniqueResidues=True
         - amino_acids_ignore_case: only supported for amino acid sequence entity types. hasUniqueResidues=True
         - amino_acids_exact_match: only supported for amino acid sequence entity types. hasUniqueResidues=True, areUniqueResiduesCaseSensitive=True
+    show_bases_in_expanded_view : bool | None = None
+        Whether the bases should be shown in the expanded view of the entity.
     _archived : bool | None
         Whether the schema is archived in Benchling.
     """
@@ -54,6 +56,7 @@ class SchemaProperties(BaseSchemaProperties):
     include_registry_id_in_chips: bool | None = False
     mixture_schema_config: MixtureSchemaConfig | None = None
     constraint_fields: set[str] = set()
+    show_bases_in_expanded_view: bool | None = False
     _archived: bool = False
 
     def __init__(self, **data: Any):
@@ -76,7 +79,10 @@ class SchemaProperties(BaseSchemaProperties):
             raise ValueError(
                 "The entity type is not a Mixture. Remove the mixture schema config."
             )
-
+        if not self.entity_type.is_sequence() and self.show_bases_in_expanded_view:
+            raise ValueError(
+                "show_bases_in_expanded_view can only be set for sequence entities."
+            )
         if self.naming_strategies and len(self.naming_strategies) == 0:
             raise ValueError(
                 "Schema must have at least 1 registry naming option enabled"

--- a/liminal/unit_dictionary/utils.py
+++ b/liminal/unit_dictionary/utils.py
@@ -1,0 +1,48 @@
+import json
+from functools import lru_cache
+
+from liminal.connection.benchling_service import BenchlingService
+
+
+@lru_cache(maxsize=1)
+def get_unit_name_to_id_map(benchling_service: BenchlingService) -> dict[str, str]:
+    response = benchling_service.api.get_response(
+        url="/api/v2-alpha/unit-types?pageSize=50"
+    )
+    unit_types = json.loads(response.content)["unitTypes"]
+    all_unit_types_flattened = {}
+    for unit_type in unit_types:
+        for unit in unit_type["units"]:
+            all_unit_types_flattened[unit["name"]] = unit["id"]
+    return all_unit_types_flattened
+
+
+def get_unit_id_from_name(benchling_service: BenchlingService, unit_name: str) -> str:
+    unit_id = get_unit_name_to_id_map(benchling_service).get(unit_name)
+    if unit_id is None:
+        raise ValueError(
+            f"Unit {unit_name} not found in Benchling Unit Dictionary. Please check the field definition or your Unit Dictionary."
+        )
+    return unit_id
+
+
+@lru_cache(maxsize=1)
+def get_unit_id_to_name_map(benchling_service: BenchlingService) -> dict[str, str]:
+    response = benchling_service.api.get_response(
+        url="/api/v2-alpha/unit-types?pageSize=50"
+    )
+    unit_types = json.loads(response.content)["unitTypes"]
+    all_unit_types_flattened = {}
+    for unit_type in unit_types:
+        for unit in unit_type["units"]:
+            all_unit_types_flattened[unit["id"]] = unit["name"]
+    return all_unit_types_flattened
+
+
+def get_unit_name_from_id(benchling_service: BenchlingService, unit_id: str) -> str:
+    unit_name = get_unit_id_to_name_map(benchling_service).get(unit_id)
+    if unit_name is None:
+        raise ValueError(
+            f"Unit {unit_id} not found in Benchling Unit Dictionary. Please check the field definition or your Unit Dictionary."
+        )
+    return unit_name


### PR DESCRIPTION
This PR allows users to define units and decimal precision on entity schema fields. An important note is that once it is defined, it cannot be changed. I've added some logging and error handling to surface this to users. However, I was unable to come up with a clean solution for when a user wants to downgrade after an upgrade revision that updates a unit. The recommendation will be that the user comments out the operation where this would occur.

Caveats are:
- unit can only be defined on number field types.
- decimal precision can only be defined on decimal field types.
- Use string name of unit that comes from Unit Dictionary. This can be defined as an enum in your codebase

Example field:
```
test = Column(name="test", type=BenchlingFieldType.DECIMAL, required=False, unit_name="second", decimal_places=3)
```
<img width="292" alt="Screenshot 2025-02-19 at 10 04 01 AM" src="https://github.com/user-attachments/assets/318574a5-dc49-46b1-b7d7-7048ca789a97" />


Tested locally with create and update operations.
<img width="767" alt="Screenshot 2025-02-19 at 9 59 58 AM" src="https://github.com/user-attachments/assets/ec3ea4d2-ffbc-4ee1-bf95-4caa6e19fcf6" />
<img width="885" alt="Screenshot 2025-02-19 at 9 59 42 AM" src="https://github.com/user-attachments/assets/601e309a-96ea-49ca-80ad-05ab2b852123" />
<img width="777" alt="Screenshot 2025-02-19 at 10 03 44 AM" src="https://github.com/user-attachments/assets/dd2e59e7-7d76-4c25-9bb2-26e3c2cda5f9" />
