### PR TITLE
update snake case and pascale case functions

### DIFF
--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -4,7 +4,7 @@ from rich import print
 
 from liminal.connection import BenchlingService
 from liminal.dropdowns.utils import get_benchling_dropdowns_dict
-from liminal.utils import pascalize, to_snake_case
+from liminal.utils import to_pascal_case, to_snake_case
 
 
 def generate_all_dropdown_files(
@@ -24,7 +24,7 @@ def generate_all_dropdown_files(
     for dropdown_name, dropdown_options in dropdowns.items():
         dropdown_values = [option.name for option in dropdown_options.options]
         options_list = str(dropdown_values).replace("'", '"')
-        classname = pascalize(dropdown_name)
+        classname = to_pascal_case(dropdown_name)
         dropdown_content = f"""
 from liminal.base.base_dropdown import BaseDropdown
 

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -8,7 +8,7 @@ from liminal.entity_schemas.utils import get_converted_tag_schemas
 from liminal.enums import BenchlingEntityType, BenchlingFieldType
 from liminal.mappers import convert_benchling_type_to_python_type
 from liminal.orm.name_template import NameTemplate
-from liminal.utils import pascalize, to_snake_case
+from liminal.utils import to_pascal_case, to_snake_case
 
 
 def get_entity_mixin(entity_type: BenchlingEntityType) -> str:
@@ -59,18 +59,18 @@ def generate_all_entity_schema_files(
     subdirectory_map: dict[str, list[tuple[str, str]]] = {}
     benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
     dropdown_name_to_classname_map: dict[str, str] = {
-        dropdown_name: pascalize(dropdown_name)
+        dropdown_name: to_pascal_case(dropdown_name)
         for dropdown_name in benchling_dropdowns.keys()
     }
     wh_name_to_classname: dict[str, str] = {
-        sp.warehouse_name: pascalize(sp.name) for sp, _, _ in models
+        sp.warehouse_name: to_pascal_case(sp.name) for sp, _, _ in models
     }
 
     for schema_properties, name_template, columns in models:
-        classname = pascalize(schema_properties.name)
+        classname = to_pascal_case(schema_properties.name)
 
     for schema_properties, name_template, columns in models:
-        classname = pascalize(schema_properties.name)
+        classname = to_pascal_case(schema_properties.name)
         filename = to_snake_case(schema_properties.name) + ".py"
         columns = {key: columns[key] for key in columns}
         import_strings = [

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -313,10 +313,15 @@ class CreateEntitySchemaField(BaseOperation):
         self.index = index
 
         self._wh_field_name: str
+        self._field_name: str
         if field_props.warehouse_name:
             self._wh_field_name = field_props.warehouse_name
         else:
             raise ValueError("Field warehouse name is required.")
+        if field_props.name:
+            self._field_name = field_props.name
+        else:
+            raise ValueError("Field name is required.")
 
     def execute(self, benchling_service: BenchlingService) -> dict[str, Any]:
         try:
@@ -385,10 +390,10 @@ class CreateEntitySchemaField(BaseOperation):
         if (
             benchling_service.connection.config_flags.schemas_enable_change_warehouse_name
             is False
-            and self.field_props.warehouse_name != to_snake_case(self.field_props.name)
+            and self.field_props.warehouse_name != to_snake_case(self._field_name)
         ):
             raise ValueError(
-                f"{self.wh_schema_name}: Tenant config flag SCHEMAS_ENABLE_CHANGE_WAREHOUSE_NAME is required to set a custom field warehouse name. Reach out to Benchling support to turn this config flag to True and then set the flag to True in BenchlingConnection.config_flags. Otherwise, define the field warehouse_name in code to be the given Benchling warehouse name: {to_snake_case(self.field_props.name)}."
+                f"{self.wh_schema_name}: Tenant config flag SCHEMAS_ENABLE_CHANGE_WAREHOUSE_NAME is required to set a custom field warehouse name. Reach out to Benchling support to turn this config flag to True and then set the flag to True in BenchlingConnection.config_flags. Otherwise, define the field warehouse_name in code to be the given Benchling warehouse name: {to_snake_case(self._field_name)}."
             )
         if (
             self.field_props.unit_name

--- a/liminal/utils.py
+++ b/liminal/utils.py
@@ -10,30 +10,25 @@ from liminal.connection.benchling_service import BenchlingService
 
 
 def generate_random_id(length: int = 8) -> str:
-    """Generate a random ID with only lowercase letters."""
+    """Generate a pseudo-random ID with only lowercase letters."""
     return "".join(random.choices(string.ascii_lowercase, k=length))
 
 
-def pascalize(input_string: str) -> str:
+def to_pascal_case(input_string: str) -> str:
     """
-    Convert a string to PascalCase.
+    Convert a string to PascalCase. Filters out any non-alphanumeric characters.
     """
-    return "".join(
-        re.sub(r"[\[\]{}():]", "", word).capitalize()
-        for word in re.split(r"[ /_\-]", input_string)
-    )
+    words = re.split(r"[ /_\-]", input_string)
+    # Then remove any non-alphanumeric characters and capitalize each word
+    return "".join(re.sub(r"[^a-zA-Z0-9]", "", word).capitalize() for word in words)
 
 
-def to_snake_case(input_string: str | None) -> str:
+def to_snake_case(input_string: str) -> str:
     """
-    Convert a string to snake_case.
+    Convert a string to snake_case. Filters out any non-alphanumeric characters.
     """
-    if input_string is None:
-        return ""
-    return "_".join(
-        re.sub(r"[\[\]{}():]", "", word).lower()
-        for word in re.split(r"[ /_\-]", input_string)
-    )
+    words = re.split(r"[ /_\-]", input_string)
+    return "_".join(re.sub(r"[^a-zA-Z0-9]", "", word).lower() for word in words)
 
 
 def to_string_val(input_val: Any) -> str:

--- a/liminal/validation/__init__.py
+++ b/liminal/validation/__init__.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from pydantic import BaseModel, ConfigDict
 
-from liminal.utils import pascalize
+from liminal.utils import to_pascal_case
 from liminal.validation.validation_severity import ValidationSeverity
 
 if TYPE_CHECKING:
@@ -137,14 +137,14 @@ def liminal_validator(
                 valid=False,
                 level=validator_level,
                 entity=self,
-                validator_name=validator_name or pascalize(func.__name__),
+                validator_name=validator_name or to_pascal_case(func.__name__),
                 message=str(e),
             )
         return BenchlingValidatorReport.create_validation_report(
             valid=True,
             level=validator_level,
             entity=self,
-            validator_name=validator_name or pascalize(func.__name__),
+            validator_name=validator_name or to_pascal_case(func.__name__),
         )
 
     setattr(wrapper, "_is_liminal_validator", True)


### PR DESCRIPTION
Updates `to_snake_case` and `to_pascal_case` to filter out any non-alphanumeric characters. These functions are used to create classnames, filenames, and "benchling given" warehouse names. All of the above should not contain any non-alphanumeric characters.