### PR TITLE
results schemas

### DIFF
--- a/liminal/base/properties/base_field_properties.py
+++ b/liminal/base/properties/base_field_properties.py
@@ -93,6 +93,8 @@ class BaseFieldProperties(BaseModel):
         return True
 
     def column_dump(self) -> dict[str, Any]:
+        """This function returns a model dump or dictionary of the field properties.
+        However, it removes defaults based on the init in the Column class."""
         column_props = self.model_dump(exclude_unset=True, exclude_none=True)
         to_pop = []
         for k, v in column_props.items():

--- a/liminal/base/properties/base_field_properties.py
+++ b/liminal/base/properties/base_field_properties.py
@@ -92,6 +92,18 @@ class BaseFieldProperties(BaseModel):
             )
         return True
 
+    def column_dump(self) -> dict[str, Any]:
+        column_props = self.model_dump(exclude_unset=True, exclude_none=True)
+        to_pop = []
+        for k, v in column_props.items():
+            if k == "is_multi" and v is False:
+                to_pop.append(k)
+            elif k == "parent_link" and v is False:
+                to_pop.append(k)
+        for k in to_pop:
+            column_props.pop(k)
+        return column_props
+
     def merge(self, new_props: BaseFieldProperties) -> dict[str, Any]:
         """Returns a diff of the two given Benchling FieldProperties as a dictionary.
         If the field is different, set it as the new field.

--- a/liminal/cli/controller.py
+++ b/liminal/cli/controller.py
@@ -7,6 +7,7 @@ from liminal.dropdowns.generate_files import generate_all_dropdown_files
 from liminal.entity_schemas.generate_files import generate_all_entity_schema_files
 from liminal.migrate.components import execute_operations, get_full_migration_operations
 from liminal.migrate.revisions_timeline import RevisionsTimeline
+from liminal.results_schemas.generate_files import generate_all_results_schema_files
 
 
 def generate_all_files(benchling_service: BenchlingService, write_path: Path) -> None:
@@ -23,6 +24,7 @@ def generate_all_files(benchling_service: BenchlingService, write_path: Path) ->
     """
     generate_all_dropdown_files(benchling_service, write_path)
     generate_all_entity_schema_files(benchling_service, write_path)
+    generate_all_results_schema_files(benchling_service, write_path)
 
 
 def autogenerate_revision_file(

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -45,6 +45,9 @@ def get_file_subdirectory(entity_type: BenchlingEntityType) -> str:
     return type_to_subdir_map[entity_type]
 
 
+TAB = "    "
+
+
 def generate_all_entity_schema_files(
     benchling_service: BenchlingService, write_path: Path
 ) -> None:
@@ -54,7 +57,6 @@ def generate_all_entity_schema_files(
         print(f"[green]Created directory: {write_path}")
 
     models = get_converted_tag_schemas(benchling_service)
-    tab = "    "
     has_date = False
     subdirectory_map: dict[str, list[tuple[str, str]]] = {}
     benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
@@ -81,7 +83,7 @@ def generate_all_entity_schema_files(
             "from liminal.enums import BenchlingEntityType, BenchlingFieldType, BenchlingNamingStrategy",
             f"from liminal.orm.mixins import {get_entity_mixin(schema_properties.entity_type)}",
         ]
-        init_strings = [f"{tab}def __init__(", f"{tab}self,"]
+        init_strings = [f"{TAB}def __init__(", f"{TAB}self,"]
         column_strings = []
         dropdowns = []
         relationship_strings = []
@@ -91,11 +93,11 @@ def generate_all_entity_schema_files(
                 dropdown_classname = dropdown_name_to_classname_map[col.dropdown_link]
                 dropdowns.append(dropdown_classname)
             column_strings.append(
-                f"""{tab}{col_name}: SqlColumn = Column(name="{col.name}", type={str(col.type)}, required={col.required}{', is_multi=True' if col.is_multi else ''}{', parent_link=True' if col.parent_link else ''}{f', entity_link="{col.entity_link}"' if col.entity_link else ''}{f', dropdown={dropdown_classname}' if dropdown_classname else ''}{f', tooltip="{col.tooltip}"' if col.tooltip else ''}{f', unit_name="{col.unit_name}"' if col.unit_name else ''}{f', decimal_places={col.decimal_places}' if col.decimal_places is not None else ''})"""
+                f"""{TAB}{col_name}: SqlColumn = Column(name="{col.name}", type={str(col.type)}, required={col.required}{', is_multi=True' if col.is_multi else ''}{', parent_link=True' if col.parent_link else ''}{f', entity_link="{col.entity_link}"' if col.entity_link else ''}{f', dropdown={dropdown_classname}' if dropdown_classname else ''}{f', tooltip="{col.tooltip}"' if col.tooltip else ''}{f', unit_name="{col.unit_name}"' if col.unit_name else ''}{f', decimal_places={col.decimal_places}' if col.decimal_places is not None else ''})"""
             )
             if col.required and col.type:
                 init_strings.append(
-                    f"""{tab}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__},"""
+                    f"""{TAB}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__},"""
                 )
 
             if (
@@ -110,14 +112,14 @@ def generate_all_entity_schema_files(
             ):
                 if not col.is_multi:
                     relationship_strings.append(
-                        f"""{tab}{col_name}_entity = single_relationship("{wh_name_to_classname[col.entity_link]}", {col_name})"""
+                        f"""{TAB}{col_name}_entity = single_relationship("{wh_name_to_classname[col.entity_link]}", {col_name})"""
                     )
                     import_strings.append(
                         "from liminal.orm.relationship import single_relationship"
                     )
                 else:
                     relationship_strings.append(
-                        f"""{tab}{col_name}_entities = multi_relationship("{wh_name_to_classname[col.entity_link]}", {col_name})"""
+                        f"""{TAB}{col_name}_entities = multi_relationship("{wh_name_to_classname[col.entity_link]}", {col_name})"""
                     )
                     import_strings.append(
                         "from liminal.orm.relationship import multi_relationship"
@@ -125,11 +127,11 @@ def generate_all_entity_schema_files(
         for col_name, col in columns.items():
             if not col.required and col.type:
                 init_strings.append(
-                    f"""{tab}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__} | None = None,"""
+                    f"""{TAB}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__} | None = None,"""
                 )
         init_strings.append("):")
         for col_name in columns.keys():
-            init_strings.append(f"{tab}self.{col_name} = {col_name}")
+            init_strings.append(f"{TAB}self.{col_name} = {col_name}")
         if len(dropdowns) > 0:
             import_strings.append(f"from ...dropdowns import {', '.join(dropdowns)}")
         if name_template != NameTemplate():
@@ -141,7 +143,7 @@ def generate_all_entity_schema_files(
         for col_name, col in columns.items():
             if col.dropdown_link:
                 init_strings.append(
-                    tab
+                    TAB
                     + dropdown_name_to_classname_map[col.dropdown_link]
                     + f".validate({col_name})"
                 )
@@ -149,7 +151,7 @@ def generate_all_entity_schema_files(
         columns_string = "\n".join(column_strings)
         relationship_string = "\n".join(relationship_strings)
         import_string = "\n".join(list(set(import_strings)))
-        init_string = f"\n{tab}".join(init_strings) if len(columns) > 0 else ""
+        init_string = f"\n{TAB}".join(init_strings) if len(columns) > 0 else ""
         full_content = f"""{import_string}
 
 

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -88,13 +88,20 @@ def generate_all_entity_schema_files(
         dropdowns = []
         relationship_strings = []
         for col_name, col in columns.items():
+            column_props = col.column_dump()
             dropdown_classname = None
             if col.dropdown_link:
                 dropdown_classname = dropdown_name_to_classname_map[col.dropdown_link]
                 dropdowns.append(dropdown_classname)
-            column_strings.append(
-                f"""{TAB}{col_name}: SqlColumn = Column(name="{col.name}", type={str(col.type)}, required={col.required}{', is_multi=True' if col.is_multi else ''}{', parent_link=True' if col.parent_link else ''}{f', entity_link="{col.entity_link}"' if col.entity_link else ''}{f', dropdown={dropdown_classname}' if dropdown_classname else ''}{f', tooltip="{col.tooltip}"' if col.tooltip else ''}{f', unit_name="{col.unit_name}"' if col.unit_name else ''}{f', decimal_places={col.decimal_places}' if col.decimal_places is not None else ''})"""
-            )
+                column_props["dropdown_link"] = dropdown_classname
+            column_props_string = ""
+            for k, v in column_props.items():
+                if k == "dropdown_link":
+                    column_props_string += f"""dropdown={v},"""
+                else:
+                    column_props_string += f"""{k}={v.__repr__()},"""
+            column_string = f"""{TAB}{col_name}: SqlColumn = Column({column_props_string.rstrip(',')})"""
+            column_strings.append(column_string)
             if col.required and col.type:
                 init_strings.append(
                     f"""{TAB}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__},"""

--- a/liminal/orm/base_model.py
+++ b/liminal/orm/base_model.py
@@ -283,8 +283,8 @@ class BaseModel(Generic[T], Base):
 
         Returns
         -------
-        list[T]
-            List of all entities from the database.
+        DataFrame
+            A pandas dataframe of all entities from the database.
         """
         query = cls.query(session)
         return pd.read_sql(query.statement, session.connection())

--- a/liminal/orm/base_results_model.py
+++ b/liminal/orm/base_results_model.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
+import inspect
 import logging
+from types import FunctionType
 from typing import Any, Generic, TypeVar  # noqa: UP035
 
+import pandas as pd  # type: ignore
 from sqlalchemy import DATETIME, Boolean, ForeignKey, String
 from sqlalchemy import Column as SqlColumn
-from sqlalchemy.orm import RelationshipProperty, relationship
+from sqlalchemy.orm import Query, RelationshipProperty, Session, relationship
 from sqlalchemy.orm.decl_api import declared_attr
 
+from liminal.base.base_validation_filters import BaseValidatorFilters
 from liminal.orm.base import Base
+from liminal.orm.base_tables.user import User
 from liminal.orm.results_schema_properties import ResultsSchemaProperties
-
-# if TYPE_CHECKING:
-#     from liminal.orm.column import Column
+from liminal.validation import BenchlingValidatorReport
 
 T = TypeVar("T")
 
@@ -46,3 +49,155 @@ class BaseResultsModel(Generic[T], Base):
         super().__init_subclass__(**kwargs)
         warehouse_name = cls.__schema_properties__.warehouse_name
         cls.__tablename__ = warehouse_name + "$raw"
+
+    @classmethod
+    def apply_base_filters(
+        cls,
+        query: Query,
+        filter_archived: bool = True,
+        filter_unregistered: bool = True,
+        base_filters: BaseValidatorFilters | None = None,
+    ) -> Query:
+        """Applies the base model filters to the given query."""
+        if filter_archived:
+            query = query.filter(cls.archived.is_(False))
+        if filter_unregistered:
+            if hasattr(cls, "is_registered"):
+                query = query.filter(cls.is_registered.is_(True))
+
+        if base_filters is None:
+            return query
+        if base_filters.created_date_start:
+            query = query.filter(cls.created_at >= base_filters.created_date_start)
+        if base_filters.created_date_end:
+            query = query.filter(cls.created_at <= base_filters.created_date_end)
+        if base_filters.updated_date_start:
+            query = query.filter(cls.modified_at >= base_filters.updated_date_start)
+        if base_filters.updated_date_end:
+            query = query.filter(cls.modified_at <= base_filters.updated_date_end)
+        if base_filters.entity_ids:
+            query = query.filter(cls.id.in_(base_filters.entity_ids))
+        if base_filters.creator_full_names:
+            query = query.filter(User.name.in_(base_filters.creator_full_names))
+        return query
+
+    @classmethod
+    def all(cls, session: Session) -> list[T]:
+        """Uses the get_query method to retrieve all entities from the database.
+
+        Parameters
+        ----------
+        session : Session
+            Benchling database session.
+
+        Returns
+        -------
+        list[T]
+            List of all entities from the database.
+        """
+        return cls.query(session).all()
+
+    @classmethod
+    def df(cls, session: Session) -> pd.DataFrame:
+        """Uses the get_query method to retrieve all entities from the database.
+
+        Parameters
+        ----------
+        session : Session
+            Benchling database session.
+
+        Returns
+        -------
+        list[T]
+            List of all entities from the database.
+        """
+        query = cls.query(session)
+        return pd.read_sql(query.statement, session.connection())
+
+    @classmethod
+    def query(cls, session: Session) -> Query:
+        """Abstract method that users can override to define a specific query
+        to retrieve entities from the database and cover any distinct relationships.
+
+        Parameters
+        ----------
+        session : Session
+            Benchling database session.
+
+        Returns
+        -------
+        Query
+            sqlalchemy query to retrieve entities from the database.
+        """
+        return session.query(cls)
+
+    @classmethod
+    def get_validators(cls) -> list[FunctionType]:
+        """Returns a list of all validators defined on the class. Validators are functions that are decorated with @validator."""
+        validators = []
+        for name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
+            if hasattr(method, "_is_liminal_validator"):
+                validators.append(method)
+        return validators
+
+    @classmethod
+    def validate(
+        cls,
+        session: Session,
+        base_filters: BaseValidatorFilters | None = None,
+        only_invalid: bool = False,
+    ) -> list[BenchlingValidatorReport]:
+        """Runs all validators for all entities returned from the query and returns a list of reports.
+        This returns a report for each entity, validator pair, regardless of whether the validation passed or failed.
+
+        Parameters
+        ----------
+        session : Session
+            Benchling database session.
+        base_filters: BaseValidatorFilters
+            Filters to apply to the query.
+        only_invalid: bool
+            If True, only returns reports for entities that failed validation.
+
+        Returns
+        -------
+        list[BenchlingValidatorReport]
+            List of reports from running all validators on all entities returned from the query.
+        """
+        results: list[BenchlingValidatorReport] = []
+        table: list[T] = cls.apply_base_filters(
+            cls.query(session), base_filters=base_filters
+        ).all()
+        logger.info(f"Validating {len(table)} entities for {cls.__name__}...")
+        validator_functions = cls.get_validators()
+        for entity in table:
+            for validator_func in validator_functions:
+                report: BenchlingValidatorReport = validator_func(entity)
+                if only_invalid and report.valid:
+                    continue
+                results.append(report)
+        return results
+
+    @classmethod
+    def validate_to_df(
+        cls,
+        session: Session,
+        base_filters: BaseValidatorFilters | None = None,
+        only_invalid: bool = False,
+    ) -> pd.DataFrame:
+        """Runs all validators for all results schema rows returned from the query and returns reports as a pandas dataframe.
+
+        Parameters
+        ----------
+        session : Session
+            Benchling database session.
+        base_filters: BaseValidatorFilters
+            Filters to apply to the query.
+
+        Returns
+        -------
+        pd.Dataframe
+            Dataframe of reports from running all validators on all entities returned from the query.
+        """
+        results = cls.validate(session, base_filters, only_invalid)
+        return pd.DataFrame([r.model_dump() for r in results])

--- a/liminal/orm/base_results_model.py
+++ b/liminal/orm/base_results_model.py
@@ -19,7 +19,7 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class BaseResultsSchemaModel(Generic[T], Base):
+class BaseResultsModel(Generic[T], Base):
     __abstract__ = True
     __schema_properties__: ResultsSchemaProperties
 

--- a/liminal/orm/base_results_schema_model.py
+++ b/liminal/orm/base_results_schema_model.py
@@ -44,4 +44,5 @@ class BaseResultsSchemaModel(Generic[T], Base):
 
     def __init_subclass__(cls, **kwargs: Any):
         super().__init_subclass__(**kwargs)
-        cls.__tablename__ = cls.__schema_properties__.warehouse_name
+        warehouse_name = cls.__schema_properties__.warehouse_name
+        cls.__tablename__ = warehouse_name + "$raw"

--- a/liminal/orm/base_results_schema_model.py
+++ b/liminal/orm/base_results_schema_model.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Generic, TypeVar  # noqa: UP035
+
+from sqlalchemy import DATETIME, Boolean, ForeignKey, String
+from sqlalchemy import Column as SqlColumn
+from sqlalchemy.orm import RelationshipProperty, relationship
+from sqlalchemy.orm.decl_api import declared_attr
+
+from liminal.orm.base import Base
+from liminal.orm.results_schema_properties import ResultsSchemaProperties
+
+# if TYPE_CHECKING:
+#     from liminal.orm.column import Column
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+
+class BaseResultsSchemaModel(Generic[T], Base):
+    __abstract__ = True
+    __schema_properties__: ResultsSchemaProperties
+
+    @declared_attr
+    def creator_id(cls) -> SqlColumn:
+        return SqlColumn(
+            "creator_id$", String, ForeignKey("user$raw.id"), nullable=True
+        )
+
+    @declared_attr
+    def creator(cls) -> RelationshipProperty:
+        return relationship("User", foreign_keys=[cls.creator_id])
+
+    id = SqlColumn("id", String, nullable=True, primary_key=True)
+    archived = SqlColumn("archived$", Boolean, nullable=True)
+    archive_purpose = SqlColumn("archive_purpose$", String, nullable=True)
+    created_at = SqlColumn("created_at$", DATETIME, nullable=True)
+    entry_id = SqlColumn("entry_id$", String, nullable=True)
+    modified_at = SqlColumn("modified_at$", DATETIME, nullable=True)
+    run_id = SqlColumn("run_id$", String, nullable=True)
+    v3_id = SqlColumn("v3_id$", String, nullable=True)
+
+    def __init_subclass__(cls, **kwargs: Any):
+        super().__init_subclass__(**kwargs)
+        cls.__tablename__ = cls.__schema_properties__.warehouse_name

--- a/liminal/orm/results_schema_properties.py
+++ b/liminal/orm/results_schema_properties.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ResultsSchemaProperties(BaseModel):
+    """
+    This class is the validated class that is public facing and inherits from the BaseSchemaProperties class.
+    It has the same fields as the BaseSchemaProperties class, but it is validated to ensure that the fields are valid.
+
+    Parameters
+    ----------
+    name : str
+        The name of the schema.
+    warehouse_name : str
+       The sql table name of the schema in the benchling warehouse.
+    """
+
+    name: str
+    warehouse_name: str
+
+    def __repr__(self) -> str:
+        """Generates a string representation of the class so that it can be executed."""
+        return f"{self.__class__.__name__}({', '.join([f'{k}={v.__repr__()}' for k, v in self.model_dump().items()])})"

--- a/liminal/orm/results_schema_properties.py
+++ b/liminal/orm/results_schema_properties.py
@@ -5,8 +5,7 @@ from pydantic import BaseModel
 
 class ResultsSchemaProperties(BaseModel):
     """
-    This class is the validated class that is public facing and inherits from the BaseSchemaProperties class.
-    It has the same fields as the BaseSchemaProperties class, but it is validated to ensure that the fields are valid.
+    This class is the validated class that is public facing, and represents the properties of a results schema properties.
 
     Parameters
     ----------

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -4,9 +4,9 @@ from rich import print
 
 from liminal.connection import BenchlingService
 from liminal.dropdowns.utils import get_benchling_dropdowns_dict
+from liminal.entity_schemas.utils import get_converted_tag_schemas
 from liminal.enums import BenchlingFieldType
 from liminal.mappers import convert_benchling_type_to_python_type
-from liminal.orm.base_model import BaseModel
 from liminal.results_schemas.utils import get_converted_results_schemas
 from liminal.utils import to_pascal_case, to_snake_case
 
@@ -23,10 +23,9 @@ def generate_all_results_schema_files(
 
     results_schemas = get_converted_results_schemas(benchling_service)
     benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
-    entity_schema_subclasses = BaseModel.get_all_subclasses()
+    tag_schemas = get_converted_tag_schemas(benchling_service)
     entity_schemas_wh_name_to_classname: dict[str, str] = {
-        s.__schema_properties__.warehouse_name: s._sa_class_manager.class_.__name__
-        for s in entity_schema_subclasses
+        sp.warehouse_name: to_pascal_case(sp.name) for sp, _, _ in tag_schemas
     }
     dropdown_name_to_classname_map: dict[str, str] = {
         dropdown_name: to_pascal_case(dropdown_name)
@@ -53,7 +52,7 @@ def generate_all_results_schema_files(
         dropdowns = []
         relationship_strings = []
         for col_name, col in field_properties_dict.items():
-            column_props = col.model_dump(exclude_unset=True, exclude_none=True)
+            column_props = col.column_dump()
             dropdown_classname = None
             if col.dropdown_link:
                 dropdown_classname = dropdown_name_to_classname_map[col.dropdown_link]
@@ -65,9 +64,7 @@ def generate_all_results_schema_files(
                     column_props_string += f"""dropdown={v},"""
                 else:
                     column_props_string += f"""{k}={v.__repr__()},"""
-            column_string = (
-                f"""{TAB}{col_name}: SqlColumn = Column({column_props_string})"""
-            )
+            column_string = f"""{TAB}{col_name}: SqlColumn = Column({column_props_string.rstrip(',')})"""
             column_strings.append(column_string)
             if col.required and col.type:
                 init_strings.append(

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+
+from rich import print
+
+from liminal.connection import BenchlingService
+from liminal.dropdowns.utils import get_benchling_dropdowns_dict
+from liminal.entity_schemas.tag_schema_models import TagSchemaModel
+from liminal.enums import BenchlingFieldType
+from liminal.mappers import convert_benchling_type_to_python_type
+from liminal.orm.base_model import BaseModel
+from liminal.results_schemas.utils import get_converted_results_schemas
+from liminal.utils import to_pascal_case, to_snake_case
+
+TAB = "    "
+
+
+def generate_all_results_schema_files(
+    benchling_service: BenchlingService, write_path: Path
+) -> None:
+    write_path = write_path / "results_schemas"
+    if not write_path.exists():
+        write_path.mkdir(parents=True, exist_ok=True)
+        print(f"[green]Created directory: {write_path}")
+
+    results_schemas = get_converted_results_schemas(benchling_service)
+    benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
+    entity_schema_subclasses = BaseModel.get_all_subclasses()
+    entity_schemas_wh_name_to_classname: dict[str, str] = {
+        s.__schema_properties__.warehouse_name: s.__class__.__name__
+        for s in entity_schema_subclasses
+    }
+    dropdown_name_to_classname_map: dict[str, str] = {
+        dropdown_name: to_pascal_case(dropdown_name)
+        for dropdown_name in benchling_dropdowns.keys()
+    }
+
+    for schema_properties, field_properties_dict in results_schemas:
+        has_date = False
+        filename = to_snake_case(schema_properties.warehouse_name) + ".py"
+        schema_name = to_pascal_case(schema_properties.warehouse_name)
+        import_strings = [
+            "from sqlalchemy import Column as SqlColumn",
+            "from liminal.base.base_results_schema import BaseResultsSchema",
+            "from liminal.orm.results_schema_properties import ResultsSchemaProperties",
+            "from liminal.orm.column import Column",
+        ]
+        init_strings = [f"{TAB}def __init__(", f"{TAB}self,"]
+        column_strings = []
+        dropdowns = []
+        relationship_strings = []
+        for col_name, col in field_properties_dict.items():
+            dropdown_classname = None
+            if col.dropdown_link:
+                dropdown_classname = dropdown_name_to_classname_map[col.dropdown_link]
+                dropdowns.append(dropdown_classname)
+            column_string = f"""{TAB}{col_name}: SqlColumn = Column({", ".join(
+            [
+                f"{k}={v.__repr__()}"
+                    for k, v in col.model_dump(
+                        exclude_unset=True, exclude_none=True
+                    ).items()
+                ]
+            )})"""
+            column_strings.append(column_string)
+            if col.required and col.type:
+                init_strings.append(
+                    f"""{TAB}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__},"""
+                )
+
+            if (
+                col.type == BenchlingFieldType.DATE
+                or col.type == BenchlingFieldType.DATETIME
+            ):
+                if not has_date:
+                    import_strings.append("from datetime import datetime")
+            if (
+                col.type in BenchlingFieldType.get_entity_link_types()
+                and col.entity_link is not None
+            ):
+                if not col.is_multi:
+                    relationship_strings.append(
+                        f"""{TAB}{col_name}_entity = single_relationship("{entity_schemas_wh_name_to_classname[col.entity_link]}", {col_name})"""
+                    )
+                    import_strings.append(
+                        "from liminal.orm.relationship import single_relationship"
+                    )
+                else:
+                    relationship_strings.append(
+                        f"""{TAB}{col_name}_entities = multi_relationship("{entity_schemas_wh_name_to_classname[col.entity_link]}", {col_name})"""
+                    )
+                    import_strings.append(
+                        "from liminal.orm.relationship import multi_relationship"
+                    )
+        for col_name, col in field_properties_dict.items():
+            if not col.required and col.type:
+                init_strings.append(
+                    f"""{TAB}{col_name}: {convert_benchling_type_to_python_type(col.type).__name__} | None = None,"""
+                )
+        init_strings.append("):")
+        for col_name in field_properties_dict.keys():
+            init_strings.append(f"{TAB}self.{col_name} = {col_name}")
+        if len(dropdowns) > 0:
+            import_strings.append(f"from ...dropdowns import {', '.join(dropdowns)}")
+        for col_name, col in field_properties_dict.items():
+            if col.dropdown_link:
+                init_strings.append(
+                    TAB
+                    + dropdown_name_to_classname_map[col.dropdown_link]
+                    + f".validate({col_name})"
+                )
+
+        import_string = "\n".join(list(set(import_strings)))
+        columns_string = "\n".join(column_strings)
+        relationship_string = "\n".join(relationship_strings)
+        init_string = (
+            f"\n{TAB}".join(init_strings) if len(field_properties_dict) > 0 else ""
+        )
+        schema_content = f"""{import_string}
+        
+
+class {schema_name}(BaseResultsSchema):
+    __schema_properties__ = {schema_properties.__repr__()}
+
+    {columns_string}
+
+    {relationship_string}
+
+    {init_string}
+"""
+
+        with open(write_path / filename, "w") as file:
+            file.write(schema_content)
+
+    with open(write_path / "__init__.py", "w") as file:
+        file.write("from .results_schemas import *")

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -140,3 +140,6 @@ class {schema_name}(BaseResultsSchemaModel):
 
     with open(write_path / "__init__.py", "w") as file:
         file.write("\n".join(init_file_imports))
+    print(
+        f"[green]Generated {write_path / '__init__.py'} with {len(results_schemas)} entity schema imports."
+    )

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -43,7 +43,7 @@ def generate_all_results_schema_files(
         )
         import_strings = [
             "from sqlalchemy import Column as SqlColumn",
-            "from liminal.orm.base_results_schema_model import BaseResultsSchemaModel",
+            "from liminal.orm.base_results_model import BaseResultsModel",
             "from liminal.orm.results_schema_properties import ResultsSchemaProperties",
             "from liminal.orm.column import Column",
             "from liminal.enums import BenchlingFieldType",
@@ -123,7 +123,7 @@ def generate_all_results_schema_files(
             f"\n{TAB}".join(init_strings) if len(field_properties_dict) > 0 else ""
         )
         schema_content = f"""{import_string}
-        
+
 
 class {schema_name}(BaseResultsSchemaModel):
     __schema_properties__ = {schema_properties.__repr__()}

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -125,7 +125,7 @@ def generate_all_results_schema_files(
         schema_content = f"""{import_string}
 
 
-class {schema_name}(BaseResultsSchemaModel):
+class {schema_name}(BaseResultsModel):
     __schema_properties__ = {schema_properties.__repr__()}
 
 {columns_string}

--- a/liminal/results_schemas/models/results_schema_model.py
+++ b/liminal/results_schemas/models/results_schema_model.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+import requests
+from pydantic import BaseModel
+
+from liminal.connection.benchling_service import BenchlingService
+from liminal.entity_schemas.tag_schema_models import TagSchemaFieldModel
+
+
+class ResultsSchemaModel(BaseModel):
+    """A pydantic model to define a tag schema, which is Benchling's internal representation of an entity schema."""
+
+    allFields: list[TagSchemaFieldModel]
+    archiveRecord: dict[str, str] | None
+    derivedParent: Any | None
+    fields: list[TagSchemaFieldModel]
+    id: str
+    name: str | None
+    organization: Any | None
+    permissions: dict[str, bool] | None
+    prefix: str | None
+    publishedDataTableColumns: Any | None
+    requestTaskSchemaIds: list[Any] | None
+    requestTemplateIds: list[Any] | None
+    sampleGroupSchema: Any | None
+    schemaType: str
+    sqlIdentifier: str | None
+
+    @classmethod
+    def get_all_json(
+        cls,
+        benchling_service: BenchlingService,
+    ) -> list[dict[str, Any]]:
+        with requests.Session() as session:
+            response = session.get(
+                f"https://{benchling_service.benchling_tenant}.benchling.com/1/api/result-schemas",
+                headers=benchling_service.custom_post_headers,
+                cookies=benchling_service.custom_post_cookies,
+            )
+        if not response.ok:
+            raise Exception("Failed to get result schemas.")
+        return response.json()["data"]
+
+    @classmethod
+    def get_all(
+        cls,
+        benchling_service: BenchlingService,
+        wh_schema_names: set[str] | None = None,
+    ) -> list[ResultsSchemaModel]:
+        schemas_data = cls.get_all_json(benchling_service)
+        filtered_schemas: list[ResultsSchemaModel] = []
+        if wh_schema_names:
+            for schema in schemas_data:
+                if schema["sqlIdentifier"] in wh_schema_names:
+                    filtered_schemas.append(cls.model_validate(schema))
+                if len(filtered_schemas) == len(wh_schema_names):
+                    break
+        else:
+            for schema in schemas_data:
+                try:
+                    filtered_schemas.append(cls.model_validate(schema))
+                except Exception as e:
+                    print(f"Error validating schema {schema['sqlIdentifier']}: {e}")
+        return filtered_schemas
+
+    @classmethod
+    def get_one(
+        cls,
+        benchling_service: BenchlingService,
+        wh_schema_name: str,
+        schemas_data: list[dict[str, Any]] | None = None,
+    ) -> ResultsSchemaModel:
+        if schemas_data is None:
+            schemas_data = cls.get_all_json(benchling_service)
+        schema = next(
+            (
+                schema
+                for schema in schemas_data
+                if schema["sqlIdentifier"] == wh_schema_name
+                and schema["registryId"] == benchling_service.registry_id
+            ),
+            None,
+        )
+        if schema is None:
+            raise ValueError(
+                f"Schema {wh_schema_name} not found in Benchling {benchling_service.benchling_tenant}."
+            )
+        return cls.model_validate(schema)
+
+    @classmethod
+    @lru_cache(maxsize=100)
+    def get_one_cached(
+        cls,
+        benchling_service: BenchlingService,
+        wh_schema_name: str,
+    ) -> ResultsSchemaModel:
+        return cls.get_one(benchling_service, wh_schema_name)

--- a/liminal/results_schemas/models/results_schema_model.py
+++ b/liminal/results_schemas/models/results_schema_model.py
@@ -11,7 +11,7 @@ from liminal.entity_schemas.tag_schema_models import TagSchemaFieldModel
 
 
 class ResultsSchemaModel(BaseModel):
-    """A pydantic model to define a tag schema, which is Benchling's internal representation of an entity schema."""
+    """A pydantic model to define a results schema, which is used when querying for results schemas from Benchling's internal API."""
 
     allFields: list[TagSchemaFieldModel]
     archiveRecord: dict[str, str] | None
@@ -34,6 +34,19 @@ class ResultsSchemaModel(BaseModel):
         cls,
         benchling_service: BenchlingService,
     ) -> list[dict[str, Any]]:
+        """This function gets all results schemas from Benchling's internal API, returning the raw JSON data.
+
+        Parameters
+        ----------
+        benchling_service : BenchlingService
+            The benchling service to use to get the results schemas.
+
+        Returns
+        -------
+        list[dict[str, Any]]
+            A list of results schemas, in their raw JSON format.
+        """
+
         with requests.Session() as session:
             response = session.get(
                 f"https://{benchling_service.benchling_tenant}.benchling.com/1/api/result-schemas",
@@ -50,6 +63,21 @@ class ResultsSchemaModel(BaseModel):
         benchling_service: BenchlingService,
         wh_schema_names: set[str] | None = None,
     ) -> list[ResultsSchemaModel]:
+        """This function gets all results schemas from Benchling's internal API.
+        If a list of warehouse names is provided, the function will only return the results schemas with the given warehouse names.
+
+        Parameters
+        ----------
+        benchling_service : BenchlingService
+            The benchling service to use to get the results schemas.
+        wh_schema_names : set[str] | None, optional
+            The set of warehouse names to filter the results schemas by. If not provided, all results schemas will be returned.
+
+        Returns
+        -------
+        list[ResultsSchemaModel]
+            A list of results schema models.
+        """
         schemas_data = cls.get_all_json(benchling_service)
         filtered_schemas: list[ResultsSchemaModel] = []
         if wh_schema_names:
@@ -73,6 +101,22 @@ class ResultsSchemaModel(BaseModel):
         wh_schema_name: str,
         schemas_data: list[dict[str, Any]] | None = None,
     ) -> ResultsSchemaModel:
+        """This function gets a singular results schema, and raises an error if a schema with the given warehouse name is not found.
+
+        Parameters
+        ----------
+        benchling_service : BenchlingService
+            The benchling service to use to get the results schema.
+        wh_schema_name : str
+            The warehouse name of the results schema to search for.
+        schemas_data : list[dict[str, Any]] | None
+            The list of results schemas to search through, to avoid making extra API calls. If not provided, the function will get all results schemas from Benchling.
+
+        Returns
+        -------
+        ResultsSchemaModel
+            The corresponding results schema model.
+        """
         if schemas_data is None:
             schemas_data = cls.get_all_json(benchling_service)
         schema = next(
@@ -97,4 +141,5 @@ class ResultsSchemaModel(BaseModel):
         benchling_service: BenchlingService,
         wh_schema_name: str,
     ) -> ResultsSchemaModel:
+        """This function gets a singular results schema from Benchling and caches it."""
         return cls.get_one(benchling_service, wh_schema_name)

--- a/liminal/results_schemas/utils.py
+++ b/liminal/results_schemas/utils.py
@@ -12,6 +12,9 @@ from liminal.unit_dictionary.utils import get_unit_id_to_name_map
 def get_converted_results_schemas(
     benchling_service: BenchlingService,
 ) -> list[tuple[ResultsSchemaProperties, dict[str, BaseFieldProperties]]]:
+    """This functions gets all Results Schema schemas from Benchling and converts them to our internal representation of a schema and its fields.
+    It parses the Results Schema and creates ResultsSchemaProperties and a list of FieldProperties for each field in the schema.
+    """
     results_schemas = ResultsSchemaModel.get_all(benchling_service)
     dropdowns_map = get_benchling_dropdown_id_name_map(benchling_service)
     unit_id_to_name_map = get_unit_id_to_name_map(benchling_service)
@@ -35,6 +38,7 @@ def get_converted_results_schemas(
 def get_results_schemas_dict(
     benchling_service: BenchlingService,
 ) -> dict[str, AssayResultSchema]:
+    """This function gets all Results Schema schemas using the Benchling API and returns a dictionary of the schemas by their system name."""
     flattened_schemas = [
         s
         for schemas in list(benchling_service.schemas.list_assay_result_schemas())

--- a/liminal/results_schemas/utils.py
+++ b/liminal/results_schemas/utils.py
@@ -1,0 +1,44 @@
+from benchling_api_client.v2.stable.models.assay_result_schema import AssayResultSchema
+
+from liminal.base.properties.base_field_properties import BaseFieldProperties
+from liminal.connection import BenchlingService
+from liminal.dropdowns.utils import get_benchling_dropdown_id_name_map
+from liminal.entity_schemas.utils import convert_tag_schema_field_to_field_properties
+from liminal.orm.results_schema_properties import ResultsSchemaProperties
+from liminal.results_schemas.models.results_schema_model import ResultsSchemaModel
+from liminal.unit_dictionary.utils import get_unit_id_to_name_map
+
+
+def get_converted_results_schemas(
+    benchling_service: BenchlingService,
+) -> list[tuple[ResultsSchemaProperties, dict[str, BaseFieldProperties]]]:
+    results_schemas = ResultsSchemaModel.get_all(benchling_service)
+    dropdowns_map = get_benchling_dropdown_id_name_map(benchling_service)
+    unit_id_to_name_map = get_unit_id_to_name_map(benchling_service)
+    results_schemas_list = []
+    for schema in results_schemas:
+        schema_properties = ResultsSchemaProperties(
+            name=schema.name,
+            warehouse_name=schema.sqlIdentifier,
+        )
+        field_properties_dict = {}
+        for field in schema.fields:
+            field_properties_dict[field.systemName] = (
+                convert_tag_schema_field_to_field_properties(
+                    field, dropdowns_map, unit_id_to_name_map
+                )
+            )
+        results_schemas_list.append((schema_properties, field_properties_dict))
+    return results_schemas_list
+
+
+def get_results_schemas_dict(
+    benchling_service: BenchlingService,
+) -> dict[str, AssayResultSchema]:
+    flattened_schemas = [
+        s
+        for schemas in list(benchling_service.schemas.list_assay_result_schemas())
+        for s in schemas
+    ]
+    schemas_dict = {s.system_name: s for s in flattened_schemas}
+    return schemas_dict


### PR DESCRIPTION
This PR adds the ability to define results schemas in code, using Liminal's base classes. This allows for querying data from the results schema classes but does not include the ability to synchronize and compare them with what is defined in Benchling.

- Adds BaseResultsSchema and ResultsSchemaProperties base classes. Results schemas use the same column class for defining fields.
- `liminal generate-files ...` command now writes results schemas
- ResultsSchemaModel pydantic model used to represent models when querying Benchling for definitions
- This PR also simplifies and cleans up how columns are printed in entity_schemas/generate_files.py. Ensured it is still equivalent output to previous method

<img width="462" alt="Screenshot 2025-04-27 at 10 41 00 AM" src="https://github.com/user-attachments/assets/48710d25-c90b-48ec-9682-a9f81782f678" />
<img width="789" alt="Screenshot 2025-04-27 at 10 40 28 AM" src="https://github.com/user-attachments/assets/e9911f71-4730-4afe-a74e-60fb5ca37a91" />
