### PR TITLE
bugfix for edge-cases in prefix and snake case

### DIFF
--- a/liminal/migrate/components.py
+++ b/liminal/migrate/components.py
@@ -76,7 +76,9 @@ def execute_operations(
             o.execute(benchling_service)
         except Exception as e:
             traceback.print_exc()
-            print(f"[bold red]Error executing operation {o.__class__.__name__}: {e}]")
+            print(
+                f"[bold red]Error at step {index} executing operation {o.__class__.__name__}: {e}]"
+            )
             return False
         index += 1
     return True

--- a/liminal/utils.py
+++ b/liminal/utils.py
@@ -28,6 +28,7 @@ def to_snake_case(input_string: str) -> str:
     Convert a string to snake_case. Filters out any non-alphanumeric characters.
     """
     words = re.split(r"[ /_\-]", input_string)
+    words = [word for word in words if word]
     return "_".join(re.sub(r"[^a-zA-Z0-9]", "", word).lower() for word in words)
 
 
@@ -59,11 +60,14 @@ def is_valid_prefix(prefix: str) -> bool:
     It must be contain only alphanumeric characters and underscores, be less than 33 characters, and end with an alphabetic character.
     """
     valid = (
-        all(c.isalnum() or c == "_" or c == "-" for c in prefix) and len(prefix) <= 32
+        all(c.isalnum() or c == "_" or c == "-" for c in prefix)
+        and len(prefix) <= 32
+        and not prefix[-1].isdigit()
+        and " " not in prefix
     )
     if not valid:
         raise ValueError(
-            f"Invalid prefix '{prefix}'. It should only contain alphabetic characters or underscores."
+            f"Invalid prefix '{prefix}'. The prefix should only contain alphabetic characters or underscores, not end end in a digit, and not contain whitespace."
         )
     return valid
 


### PR DESCRIPTION
- In prefix, follow Benchling's error handling and don't allow whitespaces or digits at the end of the prefix

- In to_snakecase, edgecase where words had empty strings. This cleans that up