### PR TITLE
specify type of files to generate in generate-files command 

### DIFF
--- a/liminal/cli/cli.py
+++ b/liminal/cli/cli.py
@@ -83,7 +83,7 @@ connection = BenchlingConnection(
 
 @app.command(
     name="generate-files",
-    help="Generates the dropdown and entity schema files from your Benchling tenant and writes to the given path.",
+    help="Generates the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path. This will overwrite any existing dropdowns, entity schemas, or results schemas that exist in the given path.",
 )
 def generate_files(
     benchling_tenant: str = typer.Argument(
@@ -95,13 +95,41 @@ def generate_files(
         "--write-path",
         help="The path to write the generated files to.",
     ),
+    entity_schemas_flag: bool = typer.Option(
+        False,
+        "-es",
+        "--entity-schemas",
+        help="Generate entity schema files.",
+    ),
+    dropdowns_flag: bool = typer.Option(
+        False,
+        "-d",
+        "--dropdowns",
+        help="Generate dropdown files.",
+    ),
+    results_schemas_flag: bool = typer.Option(
+        False,
+        "-rs",
+        "--results-schemas",
+        help="Generate results schema files.",
+    ),
 ) -> None:
     _, benchling_connection = read_local_liminal_dir(LIMINAL_DIR_PATH, benchling_tenant)
     benchling_service = BenchlingService(benchling_connection, use_internal_api=True)
     if not write_path.exists():
         write_path.mkdir()
         print(f"[green]Created directory: {write_path}")
-    generate_all_files(benchling_service, Path(write_path))
+    if not entity_schemas_flag and not dropdowns_flag and not results_schemas_flag:
+        entity_schemas_flag = True
+        dropdowns_flag = True
+        results_schemas_flag = True
+    generate_all_files(
+        benchling_service,
+        Path(write_path),
+        entity_schemas_flag,
+        dropdowns_flag,
+        results_schemas_flag,
+    )
 
 
 @app.command(

--- a/liminal/cli/controller.py
+++ b/liminal/cli/controller.py
@@ -10,10 +10,16 @@ from liminal.migrate.revisions_timeline import RevisionsTimeline
 from liminal.results_schemas.generate_files import generate_all_results_schema_files
 
 
-def generate_all_files(benchling_service: BenchlingService, write_path: Path) -> None:
-    """Initializes all the dropdown and entity schema files from your Benchling tenant and writes to the given path.
-    Creates and writes to the dropdowns/ and entity_schemas/ directories.
-    Note: This will overwrite any existing dropdowns or entity schemas that exist in the given path.
+def generate_all_files(
+    benchling_service: BenchlingService,
+    write_path: Path,
+    entity_schemas_flag: bool = True,
+    dropdowns_flag: bool = True,
+    results_schemas_flag: bool = True,
+) -> None:
+    """Initializes all the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path.
+    Creates and writes to the dropdowns/, entity_schemas/, and results_schemas/ directories.
+    Note: This will overwrite any existing dropdowns, entity schemas, or results schemas that exist in the given path.
 
     Parameters
     ----------
@@ -22,9 +28,12 @@ def generate_all_files(benchling_service: BenchlingService, write_path: Path) ->
     write_path : Path
         The path to write the generated files to.
     """
-    generate_all_dropdown_files(benchling_service, write_path)
-    generate_all_entity_schema_files(benchling_service, write_path)
-    generate_all_results_schema_files(benchling_service, write_path)
+    if dropdowns_flag:
+        generate_all_dropdown_files(benchling_service, write_path)
+    if entity_schemas_flag:
+        generate_all_entity_schema_files(benchling_service, write_path)
+    if results_schemas_flag:
+        generate_all_results_schema_files(benchling_service, write_path)
 
 
 def autogenerate_revision_file(


### PR DESCRIPTION
This PR allows users to specify the types of files to generate with the `liminal generate-files` command.

The three options are dropdowns, entity schemas, and results schemas.

No flag means generate all, include flags will generate the corresponding type.

<img width="813" alt="Screenshot 2025-05-01 at 8 23 29 AM" src="https://github.com/user-attachments/assets/c3c54a76-486e-44ef-8e19-ff70de410ab1" />
