### PR TITLE
-o option to generate-files to overwrite the specified directory

### DIFF
--- a/liminal/cli/cli.py
+++ b/liminal/cli/cli.py
@@ -83,7 +83,7 @@ connection = BenchlingConnection(
 
 @app.command(
     name="generate-files",
-    help="Generates the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path. This will overwrite any existing dropdowns, entity schemas, or results schemas that exist in the given path.",
+    help="Generates the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path. By default, this will overwrite any existing files within the {write_path}/dropdowns/, {write_path}/entity_schemas/, and {write_path}/results_schemas/ directories.",
 )
 def generate_files(
     benchling_tenant: str = typer.Argument(
@@ -113,6 +113,12 @@ def generate_files(
         "--results-schemas",
         help="Generate results schema files.",
     ),
+    overwrite: bool = typer.Option(
+        False,
+        "-o",
+        "--overwrite",
+        help="Overwrite existing files within the {write_path}/dropdowns/, {write_path}/entity_schemas/, and {write_path}/results_schemas/ directories.",
+    ),
 ) -> None:
     _, benchling_connection = read_local_liminal_dir(LIMINAL_DIR_PATH, benchling_tenant)
     benchling_service = BenchlingService(benchling_connection, use_internal_api=True)
@@ -129,6 +135,7 @@ def generate_files(
         entity_schemas_flag,
         dropdowns_flag,
         results_schemas_flag,
+        overwrite,
     )
 
 

--- a/liminal/cli/controller.py
+++ b/liminal/cli/controller.py
@@ -16,10 +16,11 @@ def generate_all_files(
     entity_schemas_flag: bool = True,
     dropdowns_flag: bool = True,
     results_schemas_flag: bool = True,
+    overwrite: bool = False,
 ) -> None:
     """Initializes all the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path.
     Creates and writes to the dropdowns/, entity_schemas/, and results_schemas/ directories.
-    Note: This will overwrite any existing dropdowns, entity schemas, or results schemas that exist in the given path.
+    Note: By default, this will overwrite any existing dropdowns, entity schemas, or results schemas that exist in the given path.
 
     Parameters
     ----------
@@ -27,13 +28,21 @@ def generate_all_files(
         The Benchling service object that is connected to a specified Benchling tenant.
     write_path : Path
         The path to write the generated files to.
+    entity_schemas_flag : bool
+        Whether to generate the entity schema files in the entity_schemas/ directory.
+    dropdowns_flag : bool
+        Whether to generate the dropdown files in the dropdowns/ directory.
+    results_schemas_flag : bool
+        Whether to generate the results schema files in the results_schemas/ directory.
+    overwrite : bool
+        Whether to overwrite existing the existing write_path directory.
     """
     if dropdowns_flag:
-        generate_all_dropdown_files(benchling_service, write_path)
+        generate_all_dropdown_files(benchling_service, write_path, overwrite)
     if entity_schemas_flag:
-        generate_all_entity_schema_files(benchling_service, write_path)
+        generate_all_entity_schema_files(benchling_service, write_path, overwrite)
     if results_schemas_flag:
-        generate_all_results_schema_files(benchling_service, write_path)
+        generate_all_results_schema_files(benchling_service, write_path, overwrite)
 
 
 def autogenerate_revision_file(

--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from rich import print
@@ -8,13 +9,24 @@ from liminal.utils import to_pascal_case, to_snake_case
 
 
 def generate_all_dropdown_files(
-    benchling_service: BenchlingService, write_path: Path
+    benchling_service: BenchlingService, write_path: Path, overwrite: bool = False
 ) -> None:
     """Generate all dropdown files from your Benchling tenant and writes to the given dropdowns/ path.
     This is used to initialize your code for Liminal and transfer the information from your Benchling tenant to your local codebase.
-    Note: This will overwrite any existing dropdowns that exist in the given path.
+
+    Parameters
+    ----------
+    benchling_service : BenchlingService
+        The Benchling service object that is connected to a specified Benchling tenant.
+    write_path : Path
+        The path to write the generated files to. dropdowns/ directory will be created within this path.
+    overwrite : bool
+        Whether to overwrite existing the existing dropdowns/ directory.
     """
     write_path = write_path / "dropdowns"
+    if write_path.exists() and overwrite:
+        shutil.rmtree(write_path)
+        print(f"[dim]Removed directory: {write_path}")
     if not write_path.exists():
         write_path.mkdir(parents=True, exist_ok=True)
         print(f"[green]Created directory: {write_path}")

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from rich import print
@@ -50,9 +51,24 @@ TAB = "    "
 
 
 def generate_all_entity_schema_files(
-    benchling_service: BenchlingService, write_path: Path
+    benchling_service: BenchlingService, write_path: Path, overwrite: bool = False
 ) -> None:
+    """Generate all entity schema files from your Benchling tenant and writes to the given entity_schemas/ path.
+    This is used to initialize your code for Liminal and transfer the information from your Benchling tenant to your local codebase.
+
+    Parameters
+    ----------
+    benchling_service : BenchlingService
+        The Benchling service object that is connected to a specified Benchling tenant.
+    write_path : Path
+        The path to write the generated files to. entity_schemas/ directory will be created within this path.
+    overwrite : bool
+        Whether to overwrite existing the existing entity_schemas/ directory.
+    """
     write_path = write_path / "entity_schemas"
+    if write_path.exists() and overwrite:
+        shutil.rmtree(write_path)
+        print(f"[dim]Removed directory: {write_path}")
     if not write_path.exists():
         write_path.mkdir(parents=True, exist_ok=True)
         print(f"[green]Created directory: {write_path}")

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -1,3 +1,4 @@
+import shutil
 from pathlib import Path
 
 from rich import print
@@ -16,9 +17,24 @@ TAB = "    "
 
 
 def generate_all_results_schema_files(
-    benchling_service: BenchlingService, write_path: Path
+    benchling_service: BenchlingService, write_path: Path, overwrite: bool = False
 ) -> None:
+    """Generate all results schema files from your Benchling tenant and writes to the given results_schemas/ path.
+    This is used to initialize your code for Liminal and transfer the information from your Benchling tenant to your local codebase.
+
+    Parameters
+    ----------
+    benchling_service : BenchlingService
+        The Benchling service object that is connected to a specified Benchling tenant.
+    write_path : Path
+        The path to write the generated files to. results_schemas/ directory will be created within this path.
+    overwrite : bool
+        Whether to overwrite existing the existing results_schemas/ directory.
+    """
     write_path = write_path / "results_schemas"
+    if write_path.exists() and overwrite:
+        shutil.rmtree(write_path)
+        print(f"[dim]Removed directory: {write_path}")
     if not write_path.exists():
         write_path.mkdir(parents=True, exist_ok=True)
         print(f"[green]Created directory: {write_path}")


### PR DESCRIPTION
Allows the ability to specify overwrite in `liminal generate-files` command. This will be especially useful for results-schemas where you want to keep results-schemas in exact sync with Benchling

<img width="847" alt="Screenshot 2025-05-01 at 8 48 01 AM" src="https://github.com/user-attachments/assets/38d51b19-af32-455e-bb08-8aa0a5ecac20" />
