### PR TITLE
overwrite flag in generate-files applies to files 

### DIFF
--- a/liminal/cli/cli.py
+++ b/liminal/cli/cli.py
@@ -83,7 +83,7 @@ connection = BenchlingConnection(
 
 @app.command(
     name="generate-files",
-    help="Generates the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path. By default, this will overwrite any existing files within the {write_path}/dropdowns/, {write_path}/entity_schemas/, and {write_path}/results_schemas/ directories.",
+    help="Generates the dropdown, entity schema, and results schema files from your Benchling tenant and writes to the given path. By default, this will not overwrite existing files.",
 )
 def generate_files(
     benchling_tenant: str = typer.Argument(
@@ -117,7 +117,7 @@ def generate_files(
         False,
         "-o",
         "--overwrite",
-        help="Overwrite existing files within the {write_path}/dropdowns/, {write_path}/entity_schemas/, and {write_path}/results_schemas/ directories.",
+        help="Overwrite the whole write directory at the given path.",
     ),
 ) -> None:
     _, benchling_connection = read_local_liminal_dir(LIMINAL_DIR_PATH, benchling_tenant)

--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -21,7 +21,7 @@ def generate_all_dropdown_files(
     write_path : Path
         The path to write the generated files to. dropdowns/ directory will be created within this path.
     overwrite : bool
-        Whether to overwrite existing the existing dropdowns/ directory.
+        Whether to overwrite existing files in the dropdowns/ directory.
     """
     write_path = write_path / "dropdowns"
     if write_path.exists() and overwrite:
@@ -47,10 +47,10 @@ class {classname}(BaseDropdown):
     __allowed_values__ = {options_list}
 """
         filename = to_snake_case(dropdown_name) + ".py"
-        with open(write_path / filename, "w") as file:
-            if overwrite:
-                file.write(dropdown_content)
-                num_files_written += 1
+        if overwrite or not (write_path / filename).exists():
+            with open(write_path / filename, "w") as file:
+                    file.write(dropdown_content)
+            num_files_written += 1
         file_names_to_classname.append((filename, classname))
 
     file_names_to_classname.sort(key=lambda x: x[0])

--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -33,6 +33,7 @@ def generate_all_dropdown_files(
 
     dropdowns = get_benchling_dropdowns_dict(benchling_service)
     file_names_to_classname = []
+    num_files_written = 0
     for dropdown_name, dropdown_options in dropdowns.items():
         dropdown_values = [option.name for option in dropdown_options.options]
         options_list = str(dropdown_values).replace("'", '"')
@@ -47,7 +48,9 @@ class {classname}(BaseDropdown):
 """
         filename = to_snake_case(dropdown_name) + ".py"
         with open(write_path / filename, "w") as file:
-            file.write(dropdown_content)
+            if overwrite:
+                file.write(dropdown_content)
+                num_files_written += 1
         file_names_to_classname.append((filename, classname))
 
     file_names_to_classname.sort(key=lambda x: x[0])
@@ -55,8 +58,13 @@ class {classname}(BaseDropdown):
         f"from .{filename[:-3]} import {classname}"
         for filename, classname in file_names_to_classname
     )
-    with open(write_path / "__init__.py", "w") as file:
-        file.write(import_statements)
+    if num_files_written > 0:
+        with open(write_path / "__init__.py", "w") as file:
+            file.write(import_statements)
         print(
-            f"[green]Generated {write_path / '__init__.py'} with {len(file_names_to_classname)} dropdown imports."
+            f"[green]Generated {write_path / '__init__.py'} with {len(file_names_to_classname)} dropdown imports. {num_files_written} dropdown files written."
+        )
+    else:
+        print(
+            "[green dim]No new dropdown files to be written. If you want to overwrite existing files, run with -o flag."
         )

--- a/liminal/dropdowns/generate_files.py
+++ b/liminal/dropdowns/generate_files.py
@@ -49,7 +49,7 @@ class {classname}(BaseDropdown):
         filename = to_snake_case(dropdown_name) + ".py"
         if overwrite or not (write_path / filename).exists():
             with open(write_path / filename, "w") as file:
-                    file.write(dropdown_content)
+                file.write(dropdown_content)
             num_files_written += 1
         file_names_to_classname.append((filename, classname))
 

--- a/liminal/entity_schemas/generate_files.py
+++ b/liminal/entity_schemas/generate_files.py
@@ -63,7 +63,7 @@ def generate_all_entity_schema_files(
     write_path : Path
         The path to write the generated files to. entity_schemas/ directory will be created within this path.
     overwrite : bool
-        Whether to overwrite existing the existing entity_schemas/ directory.
+        Whether to overwrite existing files in the entity_schemas/ directory.
     """
     write_path = write_path / "entity_schemas"
     if write_path.exists() and overwrite:
@@ -196,7 +196,7 @@ class {classname}(BaseModel, {get_entity_mixin(schema_properties.entity_type)}):
             subdirectory_num_files_written[subdirectory_name] = 0
         subdirectory_map[subdirectory_name].append((filename, classname))
         write_directory_path.mkdir(exist_ok=True)
-        if overwrite:
+        if overwrite or not (write_directory_path / filename).exists():
             with open(write_directory_path / filename, "w") as file:
                 file.write(full_content)
             subdirectory_num_files_written[subdirectory_name] += 1
@@ -212,20 +212,22 @@ class {classname}(BaseModel, {get_entity_mixin(schema_properties.entity_type)}):
             )
             with open(write_path / subdir / "__init__.py", "w") as file:
                 file.write(init_content)
-        else:
-            print(
-                f"[green dim]No new {subdir} entity schema files to be written. If you want to overwrite existing files, run with -o flag."
-            )
 
-    with open(write_path / "__init__.py", "w") as file:
-        file.write(
-            "\n".join(
-                f"from .{subdir} import * # noqa" for subdir in subdirectory_map.keys()
+    if sum(subdirectory_num_files_written.values()) > 0:
+        with open(write_path / "__init__.py", "w") as file:
+            file.write(
+                "\n".join(
+                    f"from .{subdir} import * # noqa"
+                    for subdir in subdirectory_map.keys()
+                )
+                + "\n"
             )
-            + "\n"
-        )
+            print(
+                f"[green]Generated {write_path / '__init__.py'} with {sum(subdirectory_num_files_written.values())} entity schema files written."
+            )
+    else:
         print(
-            f"[green]Generated {write_path / '__init__.py'} with {len(models)} entity schema imports."
+            "[green dim]No new entity schema files to be written. If you want to overwrite existing files, run with -o flag."
         )
 
 
@@ -242,8 +244,7 @@ def _get_dropdown_name_to_classname_map(
             for dropdown in BaseDropdown.get_all_subclasses()
         }
     benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
-    if len(benchling_dropdowns) > 0:
-        raise Exception(
-            "No dropdowns found locally. Please ensure your env.py file imports your dropdown classes or generate dropdowns from your Benchling tenant first."
-        )
-    return {}
+    return {
+        dropdown_name: to_pascal_case(dropdown_name)
+        for dropdown_name in benchling_dropdowns.keys()
+    }

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -47,6 +47,7 @@ def generate_all_results_schema_files(
         benchling_service
     )
     init_file_imports = []
+    num_files_written = 0
 
     for schema_properties, field_properties_dict in results_schemas:
         has_date = False
@@ -147,14 +148,21 @@ class {schema_name}(BaseResultsModel):
 {init_string}
 """
 
-        with open(write_path / file_name, "w") as file:
-            file.write(schema_content)
+        if overwrite:
+            with open(write_path / file_name, "w") as file:
+                file.write(schema_content)
+            num_files_written += 1
 
-    with open(write_path / "__init__.py", "w") as file:
-        file.write("\n".join(init_file_imports))
-    print(
-        f"[green]Generated {write_path / '__init__.py'} with {len(results_schemas)} entity schema imports."
-    )
+    if num_files_written > 0:
+        with open(write_path / "__init__.py", "w") as file:
+            file.write("\n".join(init_file_imports))
+        print(
+            f"[green]Generated {write_path / '__init__.py'} with {len(results_schemas)} entity schema imports. {num_files_written} results schema files written."
+        )
+    else:
+        print(
+            "[green dim]No new results schema files to be written. If you want to overwrite existing files, run with -o flag."
+        )
 
 
 def _get_dropdown_name_to_classname_map(

--- a/liminal/results_schemas/generate_files.py
+++ b/liminal/results_schemas/generate_files.py
@@ -29,7 +29,7 @@ def generate_all_results_schema_files(
     write_path : Path
         The path to write the generated files to. results_schemas/ directory will be created within this path.
     overwrite : bool
-        Whether to overwrite existing the existing results_schemas/ directory.
+        Whether to overwrite existing files in the results_schemas/ directory.
     """
     write_path = write_path / "results_schemas"
     if write_path.exists() and overwrite:
@@ -148,7 +148,7 @@ class {schema_name}(BaseResultsModel):
 {init_string}
 """
 
-        if overwrite:
+        if overwrite or not (write_path / file_name).exists():
             with open(write_path / file_name, "w") as file:
                 file.write(schema_content)
             num_files_written += 1
@@ -178,11 +178,10 @@ def _get_dropdown_name_to_classname_map(
             for dropdown in BaseDropdown.get_all_subclasses()
         }
     benchling_dropdowns = get_benchling_dropdowns_dict(benchling_service)
-    if len(benchling_dropdowns) > 0:
-        raise Exception(
-            "No dropdowns found locally. Please ensure your env.py file imports your dropdown classes or generate dropdowns from your Benchling tenant first."
-        )
-    return {}
+    return {
+        dropdown_name: to_pascal_case(dropdown_name)
+        for dropdown_name in benchling_dropdowns.keys()
+    }
 
 
 def _get_entity_schemas_wh_name_to_classname(
@@ -198,8 +197,7 @@ def _get_entity_schemas_wh_name_to_classname(
             for s in BaseModel.get_all_subclasses()
         }
     tag_schemas = get_converted_tag_schemas(benchling_service)
-    if len(tag_schemas) > 0:
-        raise Exception(
-            "No entity schemas found locally. Please ensure your env.py file imports your entity schema classes or generate entity schemas from your Benchling tenant first."
-        )
-    return {}
+    return {
+        schema_props.warehouse_name: to_pascal_case(schema_props.warehouse_name)
+        for schema_props, _, _ in tag_schemas
+    }


### PR DESCRIPTION
This clarifies the meaning of the overwrite flag in the `liminal generate-files` command. Previously, when the flag was false, existing files would be overwritten but existing files in the directory wouldn't get deleted. This was a bit misleading where you'd expected with no-overwrite for existing files to be untouched.

This PR updates the functionality of the `-o` overwrite flag to match this expected behavior. `-o` deletes the whole directory, otherwise it will only add files and not update existing files.