### PR TITLE
patch for name template fields

### DIFF
--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -449,7 +449,7 @@ class ArchiveEntitySchemaField(BaseOperation):
             p.fieldId for p in tag_schema.nameTemplateParts if p is not None
         ]
         field = tag_schema.get_field(self.wh_field_name)
-        if tag_schema.nameTemplateFields and field.id in name_template_field_ids:
+        if field.id in name_template_field_ids:
             raise ValueError(
                 f"Cannot archive field {self.wh_field_name} on entity schema {self.wh_schema_name}. Field is used in name template."
             )

--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -445,11 +445,11 @@ class ArchiveEntitySchemaField(BaseOperation):
 
     def _validate(self, benchling_service: BenchlingService) -> TagSchemaModel:
         tag_schema = TagSchemaModel.get_one(benchling_service, self.wh_schema_name)
+        name_template_field_ids = [
+            p.fieldId for p in tag_schema.nameTemplateParts if p is not None
+        ]
         field = tag_schema.get_field(self.wh_field_name)
-        if (
-            tag_schema.nameTemplateFields
-            and field.name in tag_schema.nameTemplateFields
-        ):
+        if tag_schema.nameTemplateFields and field.id in name_template_field_ids:
             raise ValueError(
                 f"Cannot archive field {self.wh_field_name} on entity schema {self.wh_schema_name}. Field is used in name template."
             )

--- a/liminal/entity_schemas/tag_schema_models.py
+++ b/liminal/entity_schemas/tag_schema_models.py
@@ -378,7 +378,6 @@ class TagSchemaModel(BaseModel):
     labelingStrategies: list[str]
     mixtureSchemaConfig: MixtureSchemaConfig | None
     name: str | None
-    nameTemplateFields: list[str] | None
     nameTemplateParts: list[NameTemplatePartModel] | None
     permissions: dict[str, bool] | None
     prefix: str | None


### PR DESCRIPTION
Fixes a bug where entity schemas couldn't be queried using Benchling's internal API due to the type schema expecting nameTemplateFields. This no longer exists which was breaking the query