### PR TITLE
only include constraint in payload when explicitly set

### DIFF
--- a/liminal/entity_schemas/operations.py
+++ b/liminal/entity_schemas/operations.py
@@ -217,10 +217,11 @@ class UpdateEntitySchema(BaseOperation):
 
     def execute(self, benchling_service: BenchlingService) -> dict[str, Any]:
         tag_schema = self._validate(benchling_service)
-        updated_tag_schema = tag_schema.update_schema_props(
-            self.update_props.model_dump(exclude_unset=True)
-        )
+        update_diff = self.update_props.model_dump(exclude_unset=True)
+        updated_tag_schema = tag_schema.update_schema_props(update_diff)
         update = UpdateTagSchemaModel(**updated_tag_schema.model_dump())
+        if "constraint_fields" not in update_diff:
+            update.constraint = None
         return update_tag_schema(benchling_service, tag_schema.id, update.model_dump())
 
     def describe_operation(self) -> str:


### PR DESCRIPTION
### Motivation
When `UpdateEntitySchema` was called to update only non-constraint properties, this would resend the existing constraint. Benchling interpreted this as attempting to add an additional constraint and would reject it as a duplicate add.

### Fix
This fix excludes the constraint from the update payload when `constraint_fields` isn't part of the requested changes