### PR TITLE
include storage link as default field type

### DIFF
--- a/liminal/enums/benchling_field_type.py
+++ b/liminal/enums/benchling_field_type.py
@@ -39,6 +39,7 @@ class BenchlingFieldType(StrEnum):
             cls.DROPDOWN,
             cls.BLOB_LINK,
             cls.ENTRY_LINK,
+            cls.STORAGE_LINK,
             *cls.get_entity_types(),
         ]
 


### PR DESCRIPTION
Includes storage link as default field type that can be set on entity schema fields