### PR TITLE
better error handling for autogenerate auth

### DIFF
--- a/liminal/connection/benchling_service.py
+++ b/liminal/connection/benchling_service.py
@@ -286,7 +286,7 @@ class BenchlingService(Benchling):
                     f"https://{benchling_tenant}.benchling.com/ext/saml/signin:begin",
                     allow_redirects=False,
                 )
-                if signin_page.status_code == 403:
+                if signin_page.status_code == 403 or signin_page.status_code == 400:
                     raise SSODisabledError(
                         f"admin_email and admin_password not provided when sso is turned off for Benchling tenant {benchling_tenant}."
                     )


### PR DESCRIPTION
Raise error for 400 error code as well when SSO is turned off for the tenant