### PR TITLE
Fix: forward client_decorator to the Benchling SDK

### DIFF
--- a/liminal/connection/benchling_service.py
+++ b/liminal/connection/benchling_service.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from playwright.async_api import async_playwright, Request
 import requests
 from benchling_sdk.auth.client_credentials_oauth2 import ClientCredentialsOAuth2
-from benchling_sdk.benchling import Benchling
+from benchling_sdk.benchling import Benchling, BenchlingApiClientDecorator
 from benchling_sdk.helpers.retry_helpers import RetryStrategy
 from bs4 import BeautifulSoup
 from sqlalchemy import create_engine
@@ -55,6 +55,10 @@ class BenchlingService(Benchling):
         Whether to connect to the Benchling Postgres database. Requires warehouse_connection_string from the connection object.
     use_internal_api: bool = False
         Whether to connect to the Benchling internal API. Requires internal_api_admin_email and internal_api_admin_password from the connection object.
+    client_decorator: BenchlingApiClientDecorator | None = None
+        An optional function that receives the default BenchlingApiClient and returns a
+        customized one. Forwarded to the Benchling SDK. A common use is raising the HTTP
+        timeout, which otherwise defaults to 10 seconds: ``lambda c: c.with_timeout(60)``.
     """
 
     def __init__(
@@ -63,6 +67,7 @@ class BenchlingService(Benchling):
         use_api: bool = True,
         use_db: bool = False,
         use_internal_api: bool = False,
+        client_decorator: BenchlingApiClientDecorator | None = None,
     ) -> None:
         self.connection = connection
         self._session: Session | None = None
@@ -77,7 +82,10 @@ class BenchlingService(Benchling):
             )
             url = f"https://{connection.tenant_name}.benchling.com"
             super().__init__(
-                url=url, auth_method=auth_method, retry_strategy=retry_strategy
+                url=url,
+                auth_method=auth_method,
+                retry_strategy=retry_strategy,
+                client_decorator=client_decorator,
             )
             LOGGER.info(f"Tenant {connection.tenant_name}: Connected to Benchling API.")
         self.use_db = use_db

--- a/liminal/tests/test_benchling_service.py
+++ b/liminal/tests/test_benchling_service.py
@@ -1,0 +1,34 @@
+from typing import cast
+
+from benchling_api_client.v2.benchling_client import BenchlingApiClient
+
+from liminal.connection.benchling_connection import BenchlingConnection
+from liminal.connection.benchling_service import BenchlingService
+
+# The Benchling SDK defaults the per-request HTTP timeout to 10 seconds.
+SDK_DEFAULT_TIMEOUT_SECONDS = 10
+
+
+def _connection() -> BenchlingConnection:
+    return BenchlingConnection(
+        tenant_name="test-tenant",
+        api_client_id="test-id",
+        api_client_secret="test-secret",
+    )
+
+
+class TestBenchlingServiceClientDecorator:
+    def test_default_timeout_is_sdk_default(self) -> None:
+        service = BenchlingService(_connection(), use_db=False)
+        assert service._client.get_timeout() == SDK_DEFAULT_TIMEOUT_SECONDS
+
+    def test_client_decorator_is_forwarded_to_sdk(self) -> None:
+        def raise_timeout(client: BenchlingApiClient) -> BenchlingApiClient:
+            # with_timeout is typed to return the base Client but preserves the subclass.
+            return cast(BenchlingApiClient, client.with_timeout(60))
+
+        service = BenchlingService(
+            _connection(), use_db=False, client_decorator=raise_timeout
+        )
+
+        assert service._client.get_timeout() == 60


### PR DESCRIPTION
## Summary

`BenchlingService` subclasses the Benchling SDK's `Benchling` class, whose `__init__` accepts a `client_decorator` for customizing the underlying `BenchlingApiClient`. But `BenchlingService.__init__` defines its own narrower signature and forwards only `url`, `auth_method`, and `retry_strategy` to `super().__init__`, so the decorator is unreachable for callers.

This PR adds an optional `client_decorator` parameter to `BenchlingService.__init__` and forwards it to the SDK. It's backwards-compatible (defaults to `None`).

Closes #209