### PR TITLE
better invalid email and password error message

### DIFF
--- a/liminal/connection/benchling_service.py
+++ b/liminal/connection/benchling_service.py
@@ -397,7 +397,7 @@ class BenchlingService(Benchling):
             )
             if not signin_response.ok:
                 raise ValueError(
-                    f"Failed to sign in to Benchling: {signin_response.text}"
+                    f"Failed to sign in to Benchling: {signin_response.reason}. Ensure your email and password are correct."
                 )
             if not signin_response.headers.get("Set-Cookie"):
                 raise ValueError(


### PR DESCRIPTION
<img width="770" height="66" alt="Screenshot 2026-08-14 at 9 07 00 AM" src="https://github.com/user-attachments/assets/3bb5ee50-250a-4eac-ba9a-ea3ffd67b8b5" />

instead of raw html text