### PR TITLE
Pin GHA to ubuntu-24.04

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -11,7 +11,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         python-version: ["3.10.8", "3.10.9"]
     runs-on: ${{ matrix.os }}
 
@@ -46,7 +46,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
         python-version: ["3.10.8", "3.10.9"]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/release-updater.yml
+++ b/.github/workflows/release-updater.yml
@@ -11,8 +11,7 @@ jobs:
       contents: write
       pull-requests: write
     name: Update Draft Release
-    runs-on:
-      - ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - id: release-drafter
         uses: release-drafter/release-drafter@v6


### PR DESCRIPTION
Ubuntu 26.04 runners are in preview, pin 24.04 to match our other repos.