### PR TITLE
chore: upgrade development Python to 3.12

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,10 +80,10 @@ jobs:
         with:
           enable-cache: true
 
-      - name: setup python ${{ matrix.python-version }}
+      - name: Setup Python 3.12
         uses: actions/setup-python@v7
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.12"
 
       - name: Install dependencies
         run: uv sync --locked --python "${{ matrix.python-version }}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #231
* #230
* #229
* #228
* #227
* #226
* #225
* #224
* #223
* __->__ #222
* #221

Co-authored-by: Cursor <cursoragent@cursor.com>