### PR TITLE
fix python version in cicd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -80,10 +80,10 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Setup Python 3.12
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: uv sync --locked --python "${{ matrix.python-version }}"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #231
* #230
* #229
* #228
* #227
* #226
* __->__ #225
* #224
* #223
* #222
* #221

