### PR TITLE
ci: keep Python version support changes focused

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,7 +9,11 @@ defaults:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        os: [ubuntu-24.04]
+        python-version: ["3.12"]
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v7
@@ -19,13 +23,13 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Setup Python 3.12
+      - name: setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --locked
+        run: uv sync
 
       - name: Cache mypy
         uses: actions/cache@v6
@@ -36,41 +40,15 @@ jobs:
             ${{ runner.os }}-mypy-
 
       - name: pre-commit
-        run: uv run --locked pre-commit run -a
-
-  build:
-    runs-on: ubuntu-24.04
-
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-        with:
-          enable-cache: true
-
-      - name: Setup Python 3.12
-        uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
-
-      - name: Build wheel
-        run: uv build --wheel
-
-      - name: Upload wheel
-        uses: actions/upload-artifact@v7
-        with:
-          name: wheel-${{ github.sha }}
-          path: dist/*.whl
-          if-no-files-found: error
+        run: |
+          uv run pre-commit run -a
 
   test:
-    needs: build
     strategy:
-      fail-fast: false
       matrix:
+        os: [ubuntu-24.04]
         python-version: ["3.10", "3.11", "3.12"]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v7
@@ -80,26 +58,13 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Setup Python ${{ matrix.python-version }}
+      - name: setup python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --locked --python "${{ matrix.python-version }}"
+        run: uv sync --python "${{ matrix.python-version }}"
 
       - name: Run tests
-        run: uv run --locked --python "${{ matrix.python-version }}" pytest liminal/
-
-      - name: Download wheel
-        uses: actions/download-artifact@v8
-        with:
-          name: wheel-${{ github.sha }}
-          path: dist
-
-      - name: Test clean wheel install
-        run: |
-          uv venv --clear .wheel-venv --python "${{ matrix.python-version }}"
-          uv pip install --python .wheel-venv/bin/python dist/*.whl
-          .wheel-venv/bin/python -I -c "import liminal"
-          .wheel-venv/bin/liminal --help
+        run: uv run --python "${{ matrix.python-version }}" pytest liminal/


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.18.0) (oldest at bottom):
* #231
* #230
* #229
* __->__ #228
* #227
* #226
* #225
* #224
* #223
* #222
* #221

Co-authored-by: Cursor <cursoragent@cursor.com>